### PR TITLE
Add support for aarch64 timer.

### DIFF
--- a/mcrouter/lib/fbi/fb_cpu_util.h
+++ b/mcrouter/lib/fbi/fb_cpu_util.h
@@ -17,24 +17,46 @@ __BEGIN_DECLS
 extern double get_cpu_frequency(void);
 extern void   bind_thread_to_cpu(int);
 
+#ifdef __aarch64__
+static inline double timer_frequency(void)
+{
+  uint64_t val;
+  asm volatile ("mrs %[rt], cntfrq_el0" : [rt] "=r" (val)) ;
+  return val;
+}
+#endif
+
 static inline uint64_t cycle_timer(void) {
+#ifdef __aarch64__
+  uint64_t val;
+  asm volatile ("mrs %[rt],cntvct_el0" : [rt] "=r" (val));
+#else
   uint32_t __a,__d;
   uint64_t val;
 
   //cpuid();
   asm volatile("rdtsc" : "=a" (__a), "=d" (__d));
   (val) = ((uint64_t)__a) | (((uint64_t)__d)<<32);
+#endif
   return val;
 }
 
 static inline double get_microseconds(double cpu_freq) {
+#ifdef __aarch64__
+  return cycle_timer() / timer_frequency();
+#else
   return cycle_timer() / cpu_freq;
+#endif
 }
 
 
 static inline uint64_t get_microsecond_from_tsc(uint64_t count,
                                                 double cpu_frequency) {
+#ifdef __aarch64__
+  return count /  timer_frequency();
+#else
   return count / cpu_frequency;
+#endif
 }
 
 __END_DECLS


### PR DESCRIPTION
This adds support ARM64 to mcrouter so it can be used with HHVM.