### PR TITLE
add standalone option --unix-domain-sock

### DIFF
--- a/mcrouter/lib/network/AsyncMcServer.cpp
+++ b/mcrouter/lib/network/AsyncMcServer.cpp
@@ -13,6 +13,7 @@
 
 #include <chrono>
 #include <condition_variable>
+#include <cstdio>
 #include <mutex>
 #include <thread>
 
@@ -225,6 +226,15 @@ class McServerThread {
           socket_.reset(new folly::AsyncServerSocket());
           socket_->useExistingSocket(opts.existingSocketFd);
         }
+      } else if (!opts.unixDomainSockPath.empty()) {
+        checkLogic(opts.ports.empty() && opts.sslPorts.empty() &&
+          (opts.existingSocketFd == -1),
+          "Can't listen on port and unix domain socket at the same time");
+        std::remove(opts.unixDomainSockPath.c_str());
+        socket_.reset(new folly::AsyncServerSocket());
+        folly::SocketAddress serverAddress;
+        serverAddress.setFromPath(opts.unixDomainSockPath);
+        socket_->bind(serverAddress);
       } else {
         checkLogic(!server_.opts_.ports.empty() ||
                    !server_.opts_.sslPorts.empty(),

--- a/mcrouter/lib/network/AsyncMcServer.h
+++ b/mcrouter/lib/network/AsyncMcServer.h
@@ -46,6 +46,13 @@ class AsyncMcServer {
     int existingSocketFd{-1};
 
     /**
+     * Create Unix Domain Socket to listen on.
+     * If this is used (not empty), port must be empty,
+     * existingSocketFd must be unset (-1).
+     */
+    std::string unixDomainSockPath;
+
+    /**
      * The list of ports to listen on.
      * If this is used, existingSocketFd must be unset (-1).
      */

--- a/mcrouter/main.cpp
+++ b/mcrouter/main.cpp
@@ -355,7 +355,8 @@ static int validate_options() {
     return 0;
   }
   if (standaloneOpts.ports.empty() &&
-      standaloneOpts.listen_sock_fd < 0) {
+      standaloneOpts.listen_sock_fd < 0 &&
+      standaloneOpts.unix_domain_sock.empty()) {
     LOG(ERROR) << "invalid ports";
     return 0;
   }

--- a/mcrouter/server.cpp
+++ b/mcrouter/server.cpp
@@ -11,6 +11,8 @@
 
 #include <signal.h>
 
+#include <cstdio>
+
 #include "mcrouter/config.h"
 #include "mcrouter/lib/network/AsyncMcServer.h"
 #include "mcrouter/lib/network/AsyncMcServerWorker.h"
@@ -126,6 +128,8 @@ void runServer(const McrouterStandaloneOptions& standaloneOpts,
 
   if (standaloneOpts.listen_sock_fd >= 0) {
     opts.existingSocketFd = standaloneOpts.listen_sock_fd;
+  } else if (!standaloneOpts.unix_domain_sock.empty()) {
+    opts.unixDomainSockPath = standaloneOpts.unix_domain_sock;
   } else {
     opts.ports = standaloneOpts.ports;
     opts.sslPorts = standaloneOpts.ssl_ports;
@@ -164,6 +168,10 @@ void runServer(const McrouterStandaloneOptions& standaloneOpts,
     LOG(INFO) << "Shutting down";
 
     McrouterInstance::freeAllMcrouters();
+
+    if (!opts.unixDomainSockPath.empty()) {
+      std::remove(opts.unixDomainSockPath.c_str());
+    }
 
   } catch (const std::exception& e) {
     LOG(ERROR) << e.what();

--- a/mcrouter/standalone_options_list.h
+++ b/mcrouter/standalone_options_list.h
@@ -48,6 +48,11 @@ mcrouter_option_integer(
   "listen-sock-fd", no_short,
   "Listen socket to take over")
 
+mcrouter_option_string(
+  unix_domain_sock, "",
+  "unix-domain-sock", no_short,
+  "Unix domain socket path")
+
 mcrouter_option_toggle(
   background, false,
   "background", 'b',


### PR DESCRIPTION
This adds an option to make mcrouter listen on unix domain socket in a standalone mode.