### PR TITLE
Use 'pid' instead of 'child_pid' for accuracy and memcached compatability

### DIFF
--- a/mcrouter/stat_list.h
+++ b/mcrouter/stat_list.h
@@ -11,7 +11,7 @@
 #define GROUP mcproxy_stats | detailed_stats
   STSS(version, MCROUTER_PACKAGE_STRING, 0)
   STSS(commandargs, "", 0)
-  STSI(child_pid, 0, 0)
+  STSI(pid, 0, 0)
   STSI(parent_pid, 0, 0)
   STUI(time, 0, 0)
 #undef GROUP

--- a/mcrouter/stats.cpp
+++ b/mcrouter/stats.cpp
@@ -360,7 +360,7 @@ void prepare_stats(McrouterInstance* router, stat_t* stats) {
   stats[config_last_attempt_stat].data.uint64 = router->lastConfigAttempt();
   stats[config_failures_stat].data.uint64 = router->configFailures();
 
-  stats[child_pid_stat].data.int64 = getpid();
+  stats[pid_stat].data.int64 = getpid();
   stats[parent_pid_stat].data.int64 = getppid();
 
   struct rusage ru;

--- a/mcrouter/test/MCProcess.py
+++ b/mcrouter/test/MCProcess.py
@@ -555,7 +555,7 @@ class Mcrouter(MCProcess):
             def get_pid():
                 stats = self.stats()
                 if stats:
-                    return int(stats['child_pid'])
+                    return int(stats['pid'])
                 return None
 
             def terminate():

--- a/mcrouter/test/test_mcrouter_managed.py
+++ b/mcrouter/test/test_mcrouter_managed.py
@@ -30,19 +30,19 @@ class TestMcrouterManagedMode(McrouterTestCase):
         proc.send_signal(sig)
         proc.wait()
 
-    def get_child_pid(self):
+    def get_pid(self):
         detailedStats = {}
         try:
             detailedStats = self.mcrouter.stats('detailed')
         except socket.error:
             return -1
 
-        if 'child_pid' in detailedStats:
-            return int(detailedStats['child_pid'])
+        if 'pid' in detailedStats:
+            return int(detailedStats['pid'])
         return -1
 
     def killChildProcess(self, sig=signal.SIGTERM):
-        pid = self.get_child_pid()
+        pid = self.get_pid()
         if pid > 0:
             try:
                 os.kill(pid, sig)


### PR DESCRIPTION
The 'child_pid' really is `mcrouter`'s pid (gotten from `getpid(2)`), so while it technically is the is the child of its parent, 'pid' is more accurate and is compatible with memcached.  In addition the 'pid' key is hardcoded in PHP's `Memcached::getStats()`.