### PR TITLE
Add timebase instructions for POWER architecture

### DIFF
--- a/mcrouter/lib/cycles/Clocks.cpp
+++ b/mcrouter/lib/cycles/Clocks.cpp
@@ -20,6 +20,11 @@ inline uint64_t rdtsc() {
   uint64_t hi, lo;
   __asm__ volatile("rdtsc" : "=a" (lo), "=d" (hi));
   return (hi << 32) | lo;
+#elif defined(__powerpc__) && \
+    ( __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8))
+  uint64_t val;
+  val = __builtin_ppc_get_timebase();
+  return val;
 #else
 #error Unsupported CPU. Consider implementing your own Clock.
 #endif

--- a/mcrouter/lib/fbi/fb_cpu_util.h
+++ b/mcrouter/lib/fbi/fb_cpu_util.h
@@ -27,12 +27,14 @@ static inline double timer_frequency(void)
 #endif
 
 static inline uint64_t cycle_timer(void) {
-#ifdef __aarch64__
   uint64_t val;
+#ifdef __aarch64__
   asm volatile ("mrs %[rt],cntvct_el0" : [rt] "=r" (val));
+#elif defined(__powerpc__) && \
+    ( __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8))
+  val = __builtin_ppc_get_timebase();
 #else
   uint32_t __a,__d;
-  uint64_t val;
 
   //cpuid();
   asm volatile("rdtsc" : "=a" (__a), "=d" (__d));


### PR DESCRIPTION
Two mcrouter functions depend on time base registers, and this patch
enables it to get from POWER architecture.

For these functions I am using the built-in __builtin_ppc_get_timebase(),
which basically read the time base registers using a set of ASM
instructions.

With this patch, the mcrouter software builds fine on ppc64el architecture.