### PR TITLE
fix boost_context when boost is 1.56+

### DIFF
--- a/mcrouter/m4/ax_boost_context.m4
+++ b/mcrouter/m4/ax_boost_context.m4
@@ -69,8 +69,16 @@ AC_DEFUN([AX_BOOST_CONTEXT],
       CXXFLAGS_SAVE=$CXXFLAGS
 
       AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-        [[@%:@include <boost/context/all.hpp>]],
-        [[boost::context::fcontext_t* fc = boost::context::make_fcontext(0, 0, 0);]])],
+        [[@%:@include <boost/context/all.hpp>
+#include <boost/version.hpp>
+]],
+        [[#if BOOST_VERSION >= 105600
+   boost::context::fcontext_t fc = boost::context::make_fcontext(0, 0, 0);
+#else
+   boost::context::fcontext_t* fc = boost::context::make_fcontext(0, 0, 0);
+#endif
+]]
+        )],
         ax_cv_boost_context=yes, ax_cv_boost_context=no)
         CXXFLAGS=$CXXFLAGS_SAVE
       AC_LANG_POP([C++])


### PR DESCRIPTION
Fixes boost::context's make_fcontext return type so mcrouter is linked properly when using Boost >= 1.56. Sidenote, configure should probably fail if it doesn't detect `-lboost_context` when you are using 1.56+.

This is the same as https://github.com/facebook/folly/commit/87bb14efca96336f339e2680ef9a49c260326fd4.