### PR TITLE
Fix Boost.Context detection

### DIFF
--- a/mcrouter/m4/ax_boost_context.m4
+++ b/mcrouter/m4/ax_boost_context.m4
@@ -70,7 +70,7 @@ AC_DEFUN([AX_BOOST_CONTEXT],
 
       AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
         [[@%:@include <boost/context/all.hpp>]],
-        [[boost::context::fcontext_t* fc = boost::context::make_fcontext(0, 0, 0);]])],
+        [[auto fc = boost::context::make_fcontext(0, 0, 0);]])],
         ax_cv_boost_context=yes, ax_cv_boost_context=no)
         CXXFLAGS=$CXXFLAGS_SAVE
       AC_LANG_POP([C++])


### PR DESCRIPTION
Since Boost 1.56, ```make_fcontext()``` returns ```fcontext_t``` instead of ```fcontext_t*```. [1][2][3]. As a result, Boost.Context is not detected correctly:
```
$ CC=clang CXX=clang++ ./configure
(...some messages omitted...)
checking whether the Boost::Context library is available... no
(...some messages omitted...)
```
And link time errors occurs:
```
$ make
(...some messages omitted...)
/bin/sh ./libtool  --tag=CXX   --mode=link clang++  -DLIBMC_FBTRACE_DISABLE  -Wno-missing-field-initializers -Wno-deprecated -O3 -g -W -Wall -Wextra -Wno-unused-parameter -fno-strict-aliasing -std=gnu++0x -g -O2   -o mcrouter mcrouter-main.o mcrouter-ManagedModeUtil.o mcrouter-server.o libmcroutercore.a lib/libmcrouter.a -lfolly -ldouble-conversion -lz -lssl -lcrypto -lcap -levent -lgflags -lglog  -L/usr/lib64  -lboost_filesystem      -lboost_system -lboost_regex -lpthread -pthread -latomic
libtool: link: clang++ -DLIBMC_FBTRACE_DISABLE -Wno-missing-field-initializers -Wno-deprecated -O3 -g -W -Wall -Wextra -Wno-unused-parameter -fno-strict-aliasing -std=gnu++0x -g -O2 -o mcrouter mcrouter-main.o mcrouter-ManagedModeUtil.o mcrouter-server.o -pthread  libmcroutercore.a lib/libmcrouter.a -lfolly -ldouble-conversion -lz -lssl -lcrypto -lcap -levent -lgflags -lglog -L/usr/lib64 -lboost_filesystem -lboost_system -lboost_regex -lpthread -latomic -pthread
/usr/bin/ld: libmcroutercore.a(libmcroutercore_a-proxy.o): undefined reference to symbol 'jump_fcontext'
/usr/lib/libboost_context.so.1.58.0: error adding symbols: DSO missing from command line
clang: error: linker command failed with exit code 1 (use -v to see invocation)
Makefile:774: recipe for target 'mcrouter' failed
(...some messages omitted...)
```

As a result, I change the variable type to ```auto```, hoping that the m4 macro works for both old and new Boost libraries.

[1] http://www.boost.org/doc/libs/1_55_0/libs/context/doc/html/context/context/boost_fcontext.html
[2] http://www.boost.org/doc/libs/1_56_0/libs/context/doc/html/context/context/boost_fcontext.html
[3] http://www.boost.org/users/history/version_1_56_0.html