### PR TITLE
Initialize non POD constant variable

### DIFF
--- a/mcrouter/lib/config/ConfigPreprocessor.cpp
+++ b/mcrouter/lib/config/ConfigPreprocessor.cpp
@@ -161,7 +161,7 @@ size_t unescapeUntil(StringPiece from, string& to, char c) {
 
 } // namespace
 
-const ConfigPreprocessor::Context ConfigPreprocessor::emptyContext_;
+const ConfigPreprocessor::Context ConfigPreprocessor::emptyContext_ = {};
 
 ///////////////////////////////Macro////////////////////////////////////////////
 


### PR DESCRIPTION
According to [a stackoverflow question](http://stackoverflow.com/q/29683381/3786245), uninitialized non-POD const variables are allowed in GCC while not in Clang, which conforms to the standard. The line in problem causes a compile error on my machine:
```
$ CC=clang CXX=clang++ ./configure
(...some messages omitted...)
$ make
(...some messages omitted...)
config/ConfigPreprocessor.cpp:164:55: error: default initialization of an object of const type
      'const ConfigPreprocessor::Context' (aka 'const unordered_map<std::string, folly::dynamic>') without a
      user-provided default constructor
const ConfigPreprocessor::Context ConfigPreprocessor::emptyContext_;
                                                      ^
config/ConfigPreprocessor.cpp:164:68: note: add an explicit initializer to initialize 'emptyContext_'
const ConfigPreprocessor::Context ConfigPreprocessor::emptyContext_;
                                                                   ^
                                                                   {}
(...some messages omitted...)
```