### PR TITLE
Make VERSION response libmemcached compatible

### DIFF
--- a/mcrouter/McrouterInstance.cpp
+++ b/mcrouter/McrouterInstance.cpp
@@ -286,7 +286,7 @@ McrouterInstance::getStartupOpts() const {
 
   auto result = opts_.toDict();
   result.insert(additionalStartupOpts_.begin(), additionalStartupOpts_.end());
-  result.emplace("version", MCROUTER_PACKAGE_STRING);
+  result.emplace("version", MCROUTER_VERSION_STRING);
   for (auto& it : result) {
     it.second = shorten(it.second, kMaxOptionValueLength);
   }

--- a/mcrouter/ServiceInfo.cpp
+++ b/mcrouter/ServiceInfo.cpp
@@ -190,7 +190,7 @@ ServiceInfo::ServiceInfoImpl::ServiceInfoImpl(proxy_t* proxy,
 
   commands_.emplace("version",
     [] (const std::vector<folly::StringPiece>& args) {
-      return MCROUTER_PACKAGE_STRING;
+      return MCROUTER_VERSION_STRING;
     }
   );
 

--- a/mcrouter/configure.ac
+++ b/mcrouter/configure.ac
@@ -1,7 +1,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.59)
-AC_INIT(mcrouter, 1.0, mcrouter@fb.com)
+AC_INIT(mcrouter, 1.0.0, mcrouter@fb.com)
 AC_CONFIG_SRCDIR([McrouterInstance.h])
 AC_CONFIG_HEADERS([config.h:config.hin])
 AC_CONFIG_LINKS([config-impl.h:mcrouter_config-impl.h])

--- a/mcrouter/main.cpp
+++ b/mcrouter/main.cpp
@@ -199,7 +199,7 @@ static void parse_options(int argc,
       print_usage_and_die(argv[0], /* errorCode */ 0);
       break;
     case 'V':
-      printf("%s\n", MCROUTER_PACKAGE_STRING);
+      printf("%s\n", MCROUTER_VERSION_STRING);
       exit(0);
       break;
 

--- a/mcrouter/mcrouter_config.h
+++ b/mcrouter/mcrouter_config.h
@@ -137,10 +137,24 @@ inline bool isMetagetAvailable() {
   return false;
 }
 
+#ifdef PACKAGE_NAME
+  #define MCROUTER_PACKAGE_NAME PACKAGE_NAME
+#else
+  #define MCROUTER_PACKAGE_NAME "mcrouter"
+#endif
+
+#ifdef PACKAGE_VERSION
+  #define MCROUTER_PACKAGE_VERSION PACKAGE_VERSION
+#else
+  #define MCROUTER_PACKAGE_VERSION "1.0.0"
+#endif
+
 #ifdef PACKAGE_STRING
   #define MCROUTER_PACKAGE_STRING PACKAGE_STRING
 #else
-  #define MCROUTER_PACKAGE_STRING "mcrouter 1.0"
+  #define MCROUTER_PACKAGE_STRING MCROUTER_PACKAGE_NAME " " MCROUTER_PACKAGE_VERSION
 #endif
+
+#define MCROUTER_VERSION_STRING MCROUTER_PACKAGE_VERSION " " MCROUTER_PACKAGE_NAME
 
 }}} // facebook::memcache::mcrouter

--- a/mcrouter/server.cpp
+++ b/mcrouter/server.cpp
@@ -150,7 +150,7 @@ bool runServer(const McrouterStandaloneOptions& standaloneOpts,
 
   opts.numThreads = mcrouterOpts.num_proxies;
 
-  opts.worker.versionString = MCROUTER_PACKAGE_STRING;
+  opts.worker.versionString = MCROUTER_VERSION_STRING;
   opts.worker.maxInFlight = standaloneOpts.max_client_outstanding_reqs;
   opts.worker.sendTimeout = std::chrono::milliseconds{
     mcrouterOpts.server_timeout_ms};

--- a/mcrouter/stat_list.h
+++ b/mcrouter/stat_list.h
@@ -9,7 +9,7 @@
  */
 // @nolint
 #define GROUP mcproxy_stats | detailed_stats
-  STSS(version, MCROUTER_PACKAGE_STRING, 0)
+  STSS(version, MCROUTER_VERSION_STRING, 0)
   STSS(commandargs, "", 0)
   STSI(pid, 0, 0)
   STSI(parent_pid, 0, 0)

--- a/mcrouter/stats.cpp
+++ b/mcrouter/stats.cpp
@@ -493,7 +493,7 @@ McReply stats_reply(proxy_t* proxy, folly::StringPiece group_str) {
   StatsReply reply;
 
   if (group_str == "version") {
-    reply.addStat("mcrouter-version", MCROUTER_PACKAGE_STRING);
+    reply.addStat("mcrouter-version", MCROUTER_VERSION_STRING);
     return reply.getMcReply();
   }
 


### PR DESCRIPTION
Swap the order of the VERSION response and add a `.0` to the version number to be compatible with `libmemcached` which [requires](http://bazaar.launchpad.net/~tangent-trunk/libmemcached/1.2/view/head:/libmemcached/response.cc#L269) the number to have three components and to come before any descriptive string.