### PR TITLE
failback can be delayed on FailoverRoute

### DIFF
--- a/mcrouter/lib/FailoverErrorsSettings.h
+++ b/mcrouter/lib/FailoverErrorsSettings.h
@@ -26,11 +26,15 @@ namespace facebook { namespace memcache {
 
 class FailoverErrorsSettings {
  public:
+  class List;
   FailoverErrorsSettings() = default;
   explicit FailoverErrorsSettings(std::vector<std::string> errors);
   FailoverErrorsSettings(std::vector<std::string> errorsGet,
                          std::vector<std::string> errorsUpdate,
                          std::vector<std::string> errorsDelete);
+  FailoverErrorsSettings(List&& listGet,
+                         List&& listUpdate,
+                         List&& listDelete);
   explicit FailoverErrorsSettings(const folly::dynamic& json);
 
   template <class Operation>
@@ -45,16 +49,32 @@ class FailoverErrorsSettings {
     return reply.isFailoverError();
   }
 
+  template <class Operation>
+  uint32_t failbackDelay(Operation) const {
+    if (GetLike<Operation>::value) {
+      return gets_.failbackDelay();
+    } else if (UpdateLike<Operation>::value) {
+      return updates_.failbackDelay();
+    } else if (DeleteLike<Operation>::value) {
+      return deletes_.failbackDelay();
+    }
+    return 0;
+  }
+
   class List {
    public:
     List() = default;
     explicit List(std::vector<std::string> errors);
+    explicit List(std::vector<std::string> errors,
+                  uint32_t failback_delay);
     explicit List(const folly::dynamic& json);
 
     bool shouldFailover(const McReply& reply) const;
+    uint32_t failbackDelay() const;
 
    private:
     std::unique_ptr<std::array<bool, mc_nres>> failover_;
+    uint32_t failback_delay_ = 0;
 
     void init(std::vector<std::string> errors);
   };

--- a/mcrouter/lib/FailoverRecorder.h
+++ b/mcrouter/lib/FailoverRecorder.h
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+#pragma once
+
+#include "mcrouter/lib/OperationTraits.h"
+
+namespace facebook { namespace memcache {
+
+class FailoverRecorder {
+ public:
+  FailoverRecorder()
+      : size_(0),
+        lastGetFailover_(std::vector<time_t>(0, 0)),
+        lastUpdateFailover_(std::vector<time_t>(0, 0)),
+        lastDeleteFailover_(std::vector<time_t>(0, 0)) {
+  };
+
+  explicit FailoverRecorder(size_t n)
+      : size_(n),
+        lastGetFailover_(std::vector<time_t>(n, 0)),
+        lastUpdateFailover_(std::vector<time_t>(n, 0)),
+        lastDeleteFailover_(std::vector<time_t>(n, 0)) {
+  };
+  FailoverRecorder(const FailoverRecorder&) = delete;
+  FailoverRecorder(FailoverRecorder&&) = default;
+  FailoverRecorder& operator=(const FailoverRecorder&) = delete;
+  FailoverRecorder& operator=(FailoverRecorder&&) = delete;
+  template <class Operation>
+  void setLastFailover(size_t idx, Operation) {
+    if (idx > size_ - 1) {
+      return;
+    }
+    time_t now;
+    time(&now);
+    if (GetLike<Operation>::value) {
+      lastGetFailover_[idx] = now;
+    } else if (UpdateLike<Operation>::value) {
+      lastUpdateFailover_[idx] = now;
+    } else if (DeleteLike<Operation>::value) {
+      lastDeleteFailover_[idx] = now;
+    }
+  }
+  template <class Operation>
+  time_t getLastFailover(size_t idx, Operation) const {
+    if (idx > size_ - 1) {
+      return 0;
+    }
+    if (GetLike<Operation>::value) {
+      return lastGetFailover_[idx];
+    } else if (UpdateLike<Operation>::value) {
+      return lastUpdateFailover_[idx];
+    } else if (DeleteLike<Operation>::value) {
+      return lastDeleteFailover_[idx];
+    }
+    return 0;
+  }
+ private:
+  const size_t size_;
+  std::vector<time_t> lastGetFailover_;
+  std::vector<time_t> lastUpdateFailover_;
+  std::vector<time_t> lastDeleteFailover_;
+};
+
+}} // facebook::memcache

--- a/mcrouter/routes/FailoverRoute.cpp
+++ b/mcrouter/routes/FailoverRoute.cpp
@@ -31,8 +31,11 @@ McrouterRouteHandlePtr makeFailoverRoute(
     return std::move(rh[0]);
   }
 
+  FailoverRecorder failoverRecorder(rh.size());;
+
   return makeMcrouterRouteHandle<FailoverRoute>(std::move(rh),
-                                                std::move(failoverErrors));
+                                                std::move(failoverErrors),
+                                                std::move(failoverRecorder));
 }
 
 McrouterRouteHandlePtr makeFailoverRoute(


### PR DESCRIPTION
* This new feature would enable failback to be delayed for specified seconds on FailoverRoute.

    * To turn on the feature, failover_errors would be like the following:
    ```
# allow "gets" to do failback if 3600 seconds passed since last failover
# allow "updates" to do failback if 10 seconds passed since last failover
# "delete" is missing, default behavior (all errors) will be assumed with no failback delay (0 seconds).
{
    "gets": {
        "when": [ "tko" ],
        "failback_delay": 3600
    },
    "updates": {
        "when": [ "connect_timeout", "timeout", "connect_error", "tko" ],
        "failback_delay": 10
    }
}
```
    * a bit misleading point is that delay time is counted from the time last failover occurs, not last failback. So if more than failback_delay seconds have passed in failure state all the time, no failback delay will seem to happen. The reason why I chose it to be like so is that:
        * it keeps us from doing a bit tricky stuff like periodically checking if any child route handler in failure becomes available (maybe with dummy "get" operation to see response error without any harm), or always "ping"-ing before the real routing job.
        * it's still practically useful in some cases like what I wrote down in 'use case scenarios.'

* use case scenarios:
    * ~~when we may want to avoid failover flapping~~ (<- removed after my post https://github.com/facebook/mcrouter/pull/71#issuecomment-120170685 )
    * when we use backend memcached servers as almost like short-term item storage(!) rather than pure cache, "gets" failback delay might help a lot

* I would appreciate if you could give me:
    * any thoughts of the idea of implementing failback delay itself in the first place,
    * any code design issues plus if possible idea for refactoring,
    * or any other kind of opinions or advice.