### PR TITLE
Reverse version and name in version response for compatibility with libmemcached

### DIFF
--- a/mcrouter/configure.ac
+++ b/mcrouter/configure.ac
@@ -9,6 +9,8 @@ m4_append([mcrouter_version], [.0])
 m4_append([mcrouter_version], [mcrouter_version_suffix])
 AC_INIT([mcrouter], [mcrouter_version], mcrouter@fb.com)
 
+AC_DEFINE_UNQUOTED([MCROUTER_PACKAGE_STRING], ["AC_PACKAGE_VERSION AC_PACKAGE_NAME"], [Full name and version of this package, with version coming first for libmemcached compatibility])
+
 AC_CONFIG_SRCDIR([McrouterInstance.h])
 AC_CONFIG_HEADERS([config.h:config.hin])
 AC_CONFIG_LINKS([config-impl.h:mcrouter_config-impl.h])

--- a/mcrouter/mcrouter_config.h
+++ b/mcrouter/mcrouter_config.h
@@ -153,10 +153,8 @@ inline bool isMetagetAvailable() {
 
 void insertCustomStartupOpts(folly::dynamic& options);
 
-#ifdef PACKAGE_STRING
-  #define MCROUTER_PACKAGE_STRING PACKAGE_STRING
-#else
-  #define MCROUTER_PACKAGE_STRING "mcrouter 1.0"
+#ifndef MCROUTER_PACKAGE_STRING
+  #define MCROUTER_PACKAGE_STRING "1.0.0 mcrouter"
 #endif
 
 }}} // facebook::memcache::mcrouter


### PR DESCRIPTION
This is basically the same as the original patch from #62. For some reason the final commit that closed #62 didn't actually reverse the name and version, so all clients that use libmemcached still barf when they ask for the version.