### PR TITLE
[mcrouter] Add build scripts for Ubuntu 16.04

### DIFF
--- a/mcrouter/scripts/install_ubuntu_16.04.sh
+++ b/mcrouter/scripts/install_ubuntu_16.04.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -ex
+
+[ -n "$1" ] || ( echo "Install dir missing"; exit 1 )
+
+sudo apt-get update
+
+sudo apt-get install -y \
+    autoconf \
+    binutils-dev \
+    bison \
+    cmake \
+    flex \
+    g++ \
+    gcc \
+    git \
+    libboost1.58-all-dev \
+    libdouble-conversion-dev \
+    libevent-dev \
+    libgflags-dev \
+    libgoogle-glog-dev \
+    libjemalloc-dev \
+    libssl-dev \
+    libtool \
+    make \
+    python-dev \
+    ragel
+
+cd "$(dirname "$0")" || ( echo "cd fail"; exit 1 )
+
+./get_and_build_everything.sh ubuntu-16.04 "$@"

--- a/mcrouter/scripts/order_ubuntu-16.04/10_folly
+++ b/mcrouter/scripts/order_ubuntu-16.04/10_folly
@@ -1,0 +1,1 @@
+../recipes/folly.sh

--- a/mcrouter/scripts/order_ubuntu-16.04/12_wangle
+++ b/mcrouter/scripts/order_ubuntu-16.04/12_wangle
@@ -1,0 +1,1 @@
+../recipes/wangle.sh

--- a/mcrouter/scripts/order_ubuntu-16.04/15_fbthrift
+++ b/mcrouter/scripts/order_ubuntu-16.04/15_fbthrift
@@ -1,0 +1,1 @@
+../recipes/fbthrift.sh

--- a/mcrouter/scripts/order_ubuntu-16.04/20_mcrouter
+++ b/mcrouter/scripts/order_ubuntu-16.04/20_mcrouter
@@ -1,0 +1,1 @@
+../recipes/mcrouter.sh


### PR DESCRIPTION
Summary: Ubuntu 16.04 is [released](https://wiki.ubuntu.com/XenialXerus/ReleaseNotes). The only difference from 15.04 script is newer boost version (1.58 vs 1.55).

Test Plan: built on fresh Ubuntu 16.04 installation.