### PR TITLE
[mcrouter] Fix some compiler warnings

### DIFF
--- a/mcrouter/lib/CompressionCodecManager.cpp
+++ b/mcrouter/lib/CompressionCodecManager.cpp
@@ -113,9 +113,8 @@ CompressionCodec* CompressionCodecMap::get(uint32_t id) const noexcept {
 
 CompressionCodec* CompressionCodecMap::getBest(
     const CodecIdRange& codecRange) const noexcept {
-  uint32_t lastId = codecRange.firstId + codecRange.size - 1;
-  for (int64_t i = lastId; i >= codecRange.firstId; --i) {
-    if (auto codec = get(i)) {
+  for (int64_t i = static_cast<int64_t>(codecRange.size) - 1; i >= 0; --i) {
+    if (auto codec = get(static_cast<uint32_t>(codecRange.firstId + i))) {
       return codec;
     }
   }

--- a/mcrouter/lib/fbi/cpp/Trie-inl.h
+++ b/mcrouter/lib/fbi/cpp/Trie-inl.h
@@ -25,7 +25,7 @@ Trie<Value>::Trie(const Trie& other)
     value_ = folly::make_unique<value_type>(*other.value_);
   }
 
-  for (auto edge = 0; edge < kNumChars; ++edge) {
+  for (size_t edge = 0; edge < kNumChars; ++edge) {
     if (other.next_[edge]) {
       next_[edge] = folly::make_unique<Trie>(*other.next_[edge]);
       next_[edge]->parent_ = this;
@@ -39,7 +39,7 @@ Trie<Value>::Trie(Trie&& other) noexcept
       value_(std::move(other.value_)),
       parent_(other.parent_),
       c_(other.c_) {
-  for (auto edge = 0; edge < kNumChars; ++edge) {
+  for (size_t edge = 0; edge < kNumChars; ++edge) {
     if (next_[edge]) {
       next_[edge]->parent_ = this;
     }
@@ -59,7 +59,7 @@ Trie<Value>& Trie<Value>::operator=(Trie&& other) {
   parent_ = other.parent_;
   c_ = other.c_;
 
-  for (auto edge = 0; edge < kNumChars; ++edge) {
+  for (size_t edge = 0; edge < kNumChars; ++edge) {
     if (next_[edge]) {
       next_[edge]->parent_ = this;
     }

--- a/mcrouter/lib/network/test/McQueueAppenderTest.cpp
+++ b/mcrouter/lib/network/test/McQueueAppenderTest.cpp
@@ -63,9 +63,9 @@ TEST(McQueueAppenderTest, longString) {
   // Read the serialized data back in and check that it's what we wrote.
   UmbrellaMessageInfo inputHeader;
   caretParseHeader((uint8_t*)input.data(), input.length(), inputHeader);
-  EXPECT_EQ(123, inputHeader.typeId);
-  EXPECT_EQ(456, inputHeader.reqId);
-  EXPECT_EQ(17, inputHeader.traceId);
+  EXPECT_EQ(123u, inputHeader.typeId);
+  EXPECT_EQ(456u, inputHeader.reqId);
+  EXPECT_EQ(17u, inputHeader.traceId);
 
   TypedThriftReply<cpp2::McGetReply> inputReply;
   apache::thrift::CompactProtocolReader reader;
@@ -165,9 +165,9 @@ TEST(McQueueAppender, manyFields) {
   // Read the serialized data back in and check that it's what we wrote.
   UmbrellaMessageInfo inputHeader;
   caretParseHeader((uint8_t*)input.data(), input.length(), inputHeader);
-  EXPECT_EQ(123, inputHeader.typeId);
-  EXPECT_EQ(456, inputHeader.reqId);
-  EXPECT_EQ(17, inputHeader.traceId);
+  EXPECT_EQ(123u, inputHeader.typeId);
+  EXPECT_EQ(456u, inputHeader.reqId);
+  EXPECT_EQ(17u, inputHeader.traceId);
 
   cpp2::ManyFields tstruct2;
   apache::thrift::CompactProtocolReader reader;


### PR DESCRIPTION
Many signed/unsigned comparisons; one looks like a real bug `uint32_t lastId = codecRange.firstId + codecRange.size - 1;` - when range is empty, we have integer underflow. Also `coalesceSlow` is not used when there is no liblz4 installed. Gentrified `awriter_test` a bit.