### PR TITLE
Create canned route configurations

### DIFF
--- a/mcrouter/examples/README.md
+++ b/mcrouter/examples/README.md
@@ -6,7 +6,7 @@ This section shows canned mcrouter configurations that can be used to ramp up qu
 
 ## sharded_repl_async_missfailover.json
 
-<pre
+
 "pools": {
    "A": {
       "servers": [
@@ -37,7 +37,8 @@ This section shows canned mcrouter configurations that can be used to ramp up qu
 }
 
 Explanation: The above configuration allows users to set up 2 memcache pools where keys will be sharded based on the default hashing algorithm.
-1) The OperationSelectorRoute with the default AllAsyncRoute configuration will send all mutations to both pools asynchronously.
-2) If any of memcached node(s) in Pool A go down, all set ops will bypass the node(s) and continue on in Pool B.
-3) If any of memcached node(s) in Pool A go down, some get ops will result in a cache miss and get re-directed seamlessly to Pool B.
-4) When the memcached node comes back up, it will be empty. Mcrouter will continue to fulfill get requests from Pool B.
+
+    1) The OperationSelectorRoute with the default AllAsyncRoute configuration will send all mutations to both pools asynchronously
+    2) If any of memcached node(s) in Pool A go down, all set ops will bypass the node(s) and continue on in Pool B
+    3) If any of memcached node(s) in Pool A go down, some get ops will result in a cache miss and get re-directed seamlessly to Pool B
+    4) When the memcached node comes back up, it will be empty. Mcrouter will continue to fulfill get requests from Pool B

--- a/mcrouter/examples/README.md
+++ b/mcrouter/examples/README.md
@@ -6,7 +6,7 @@ This section shows canned mcrouter configurations that can be used to ramp up qu
 
 ## sharded_repl_async_missfailover.json
 
-<```
+<pre
 "pools": {
    "A": {
       "servers": [
@@ -35,8 +35,9 @@ This section shows canned mcrouter configurations that can be used to ramp up qu
   }
 }
 }
-```
+
 Explanation: The above configuration allows users to set up 2 memcache pools where keys will be sharded based on the default hashing algorithm.
 1) The OperationSelectorRoute with the default AllAsyncRoute configuration will send all mutations to both pools asynchronously.
 2) If any of memcached node(s) in Pool A go down, all set ops will bypass the node(s) and continue on in Pool B.
 3) If any of memcached node(s) in Pool A go down, some get ops will result in a cache miss and get re-directed seamlessly to Pool B.
+4) When the memcached node comes back up, it will be empty. Mcrouter will continue to fulfill get requests from Pool B.

--- a/mcrouter/examples/README.md
+++ b/mcrouter/examples/README.md
@@ -7,34 +7,34 @@ This section shows canned mcrouter configurations that can be used to ramp up qu
 ## sharded_repl_async_missfailover.json
 
 
-"pools": {
-   "A": {
-      "servers": [
-          "192.168.45.101:11211",
-          "192.168.45.102:11211"
-      ]
-  },
-  "B": {
-     "servers": [
-         "192.168.45.103:11211",
-         "192.168.45.104:11211"
-     ]
-  }
-},
-"route": {
-  "type": "OperationSelectorRoute",
-  "default_policy": {
-      "type": "AllAsyncRoute",
-      "children": [ "PoolRoute|A", "PoolRoute|B" ]
-  },
-  "operation_policies": {
-     "get": {
-         "type": "MissFailoverRoute",
-         "children": [ "PoolRoute|A", "PoolRoute|B" ]
-     }
-  }
-}
-}
+    "pools": {
+       "A": {
+          "servers": [
+              "192.168.45.101:11211",
+              "192.168.45.102:11211"
+          ]
+      },
+      "B": {
+         "servers": [
+             "192.168.45.103:11211",
+             "192.168.45.104:11211"
+         ]
+      }
+    },
+    "route": {
+      "type": "OperationSelectorRoute",
+      "default_policy": {
+          "type": "AllAsyncRoute",
+          "children": [ "PoolRoute|A", "PoolRoute|B" ]
+      },
+      "operation_policies": {
+         "get": {
+             "type": "MissFailoverRoute",
+             "children": [ "PoolRoute|A", "PoolRoute|B" ]
+         }
+      }
+    }
+    }
 
 Explanation: The above configuration allows users to set up 2 memcache pools where keys will be sharded based on the default hashing algorithm.
 

--- a/mcrouter/examples/README.md
+++ b/mcrouter/examples/README.md
@@ -40,7 +40,7 @@ The above configuration allows users to set up 2x2 memcache pools where keys wil
 * The OperationSelectorRoute with the default AllAsyncRoute configuration will send all mutations to both pools asynchronously
 * If any of memcached node(s) in Pool A go down, all set ops will bypass the node(s) and continue on in Pool B
 * If any of memcached node(s) in Pool A go down, some get ops will result in a cache miss and get re-directed seamlessly to Pool B
-* When the memcached node comes back up, it will be empty. Mcrouter will continue to fulfill get requests from Pool B
+* When the memcached node(s) come back up, they'll be empty. Mcrouter will continue to fulfill get requests from Pool B
 
 ## Links
 

--- a/mcrouter/examples/README.md
+++ b/mcrouter/examples/README.md
@@ -2,10 +2,7 @@
 
 This section shows canned mcrouter configurations that can help users ramp up quickly.
 
-## Quick start guide
-
 ## sharded_repl_async_missfailover.json
-
 
     "pools": {
        "A": {
@@ -36,10 +33,10 @@ This section shows canned mcrouter configurations that can help users ramp up qu
     }
     }
 
-Overview
+## Overview
 The above configuration allows users to set up 2x2 memcache pools where keys will be sharded based on the default hashing algorithm.
 
-Explanation
+## Explanation
     1) The OperationSelectorRoute with the default AllAsyncRoute configuration will send all mutations to both pools asynchronously
     2) If any of memcached node(s) in Pool A go down, all set ops will bypass the node(s) and continue on in Pool B
     3) If any of memcached node(s) in Pool A go down, some get ops will result in a cache miss and get re-directed seamlessly to Pool B

--- a/mcrouter/examples/README.md
+++ b/mcrouter/examples/README.md
@@ -1,6 +1,6 @@
 # Mcrouter [![Build Status](https://travis-ci.org/facebook/mcrouter.svg?branch=master)](https://travis-ci.org/facebook/mcrouter)
 
-This section shows canned mcrouter configurations that can be used to ramp up quickly.
+This section shows canned mcrouter configurations that can help users ramp up quickly.
 
 ## Quick start guide
 
@@ -36,9 +36,24 @@ This section shows canned mcrouter configurations that can be used to ramp up qu
     }
     }
 
-Explanation: The above configuration allows users to set up 2 memcache pools where keys will be sharded based on the default hashing algorithm.
+Overview
+The above configuration allows users to set up 2x2 memcache pools where keys will be sharded based on the default hashing algorithm.
 
+Explanation
     1) The OperationSelectorRoute with the default AllAsyncRoute configuration will send all mutations to both pools asynchronously
     2) If any of memcached node(s) in Pool A go down, all set ops will bypass the node(s) and continue on in Pool B
     3) If any of memcached node(s) in Pool A go down, some get ops will result in a cache miss and get re-directed seamlessly to Pool B
     4) When the memcached node comes back up, it will be empty. Mcrouter will continue to fulfill get requests from Pool B
+
+## Links
+
+Documentation: https://github.com/facebook/mcrouter/wiki
+Engineering discussions and support: https://www.facebook.com/groups/mcrouter
+
+## License
+
+Copyright (c) 2016, Facebook, Inc.
+All rights reserved.
+
+Licensed under a BSD license:
+https://github.com/facebook/mcrouter/blob/master/LICENSE

--- a/mcrouter/examples/README.md
+++ b/mcrouter/examples/README.md
@@ -1,0 +1,42 @@
+# Mcrouter [![Build Status](https://travis-ci.org/facebook/mcrouter.svg?branch=master)](https://travis-ci.org/facebook/mcrouter)
+
+This section shows canned mcrouter configurations that can be used to ramp up quickly.
+
+## Quick start guide
+
+## sharded_repl_async_missfailover.json
+
+<```
+"pools": {
+   "A": {
+      "servers": [
+          "192.168.45.101:11211",
+          "192.168.45.102:11211"
+      ]
+  },
+  "B": {
+     "servers": [
+         "192.168.45.103:11211",
+         "192.168.45.104:11211"
+     ]
+  }
+},
+"route": {
+  "type": "OperationSelectorRoute",
+  "default_policy": {
+      "type": "AllAsyncRoute",
+      "children": [ "PoolRoute|A", "PoolRoute|B" ]
+  },
+  "operation_policies": {
+     "get": {
+         "type": "MissFailoverRoute",
+         "children": [ "PoolRoute|A", "PoolRoute|B" ]
+     }
+  }
+}
+}
+```
+Explanation: The above configuration allows users to set up 2 memcache pools where keys will be sharded based on the default hashing algorithm.
+1) The OperationSelectorRoute with the default AllAsyncRoute configuration will send all mutations to both pools asynchronously.
+2) If any of memcached node(s) in Pool A go down, all set ops will bypass the node(s) and continue on in Pool B.
+3) If any of memcached node(s) in Pool A go down, some get ops will result in a cache miss and get re-directed seamlessly to Pool B.

--- a/mcrouter/examples/README.md
+++ b/mcrouter/examples/README.md
@@ -36,7 +36,7 @@ This section shows canned mcrouter configurations that can help users ramp up qu
 ## Overview
 The above configuration allows users to set up 2x2 memcache pools where keys will be sharded based on the default hashing algorithm.
 
-## Explanation
+## Route Explanation
 * The OperationSelectorRoute with the default AllAsyncRoute configuration will send all mutations to both pools asynchronously
 * If any of memcached node(s) in Pool A go down, all set ops will bypass the node(s) and continue on in Pool B
 * If any of memcached node(s) in Pool A go down, some get ops will result in a cache miss and get re-directed seamlessly to Pool B

--- a/mcrouter/examples/README.md
+++ b/mcrouter/examples/README.md
@@ -37,10 +37,10 @@ This section shows canned mcrouter configurations that can help users ramp up qu
 The above configuration allows users to set up 2x2 memcache pools where keys will be sharded based on the default hashing algorithm.
 
 ## Explanation
-    1) The OperationSelectorRoute with the default AllAsyncRoute configuration will send all mutations to both pools asynchronously
-    2) If any of memcached node(s) in Pool A go down, all set ops will bypass the node(s) and continue on in Pool B
-    3) If any of memcached node(s) in Pool A go down, some get ops will result in a cache miss and get re-directed seamlessly to Pool B
-    4) When the memcached node comes back up, it will be empty. Mcrouter will continue to fulfill get requests from Pool B
+* The OperationSelectorRoute with the default AllAsyncRoute configuration will send all mutations to both pools asynchronously
+* If any of memcached node(s) in Pool A go down, all set ops will bypass the node(s) and continue on in Pool B
+* If any of memcached node(s) in Pool A go down, some get ops will result in a cache miss and get re-directed seamlessly to Pool B
+* When the memcached node comes back up, it will be empty. Mcrouter will continue to fulfill get requests from Pool B
 
 ## Links
 

--- a/mcrouter/examples/sharded_repl_async_missfailover.json
+++ b/mcrouter/examples/sharded_repl_async_missfailover.json
@@ -1,0 +1,29 @@
+{
+   "pools": {
+      "A": {
+         "servers": [
+             "192.168.45.101:11211",
+             "192.168.45.102:11211"
+         ]
+     },
+     "B": {
+        "servers": [
+            "192.168.45.103:11211",
+            "192.168.45.104:11211"
+        ]
+     }
+   },
+   "route": {
+     "type": "OperationSelectorRoute",
+     "default_policy": {
+         "type": "AllAsyncRoute",
+         "children": [ "PoolRoute|A", "PoolRoute|B" ]
+     },
+     "operation_policies": {
+        "get": {
+            "type": "MissFailoverRoute",
+            "children": [ "PoolRoute|A", "PoolRoute|B" ]
+        }
+     }
+   }
+ }


### PR DESCRIPTION
The idea is to provide pre-canned route configurations. This will help users in multiple ways:
1) Act as a tutorial for using multiple route configurations together to address a requirement.
2) Allow users to hit the ground running. They can use such configurations and get going right away.
