### PR TITLE
fix: add pkg-config install to Dockerfile

### DIFF
--- a/mcrouter/scripts/docker/Dockerfile
+++ b/mcrouter/scripts/docker/Dockerfile
@@ -6,7 +6,7 @@ ENV             MCROUTER_DIR            /usr/local/mcrouter
 ENV             MCROUTER_REPO           https://github.com/facebook/mcrouter.git
 ENV             DEBIAN_FRONTEND         noninteractive
 
-RUN             apt-get update && apt-get install -y git && \
+RUN             apt-get update && apt-get install -y git pkg-config && \
                 mkdir -p $MCROUTER_DIR/repo && \
                 cd $MCROUTER_DIR/repo && git clone $MCROUTER_REPO && \
                 cd $MCROUTER_DIR/repo/mcrouter/mcrouter/scripts && \


### PR DESCRIPTION
add pkg-config install to Dockerfile
for https://github.com/facebook/mcrouter/issues/154

@jmswen, Thank you for merge my previous pr https://github.com/facebook/mcrouter/pull/162.

but, my original commit was missing in there.

'pkg-config' have to be in Dockerfile too.  