### PR TITLE
Fix Dockerfile dependencies for add-apt-repository

### DIFF
--- a/mcrouter/scripts/docker/Dockerfile
+++ b/mcrouter/scripts/docker/Dockerfile
@@ -6,7 +6,7 @@ ENV             MCROUTER_DIR            /usr/local/mcrouter
 ENV             MCROUTER_REPO           https://github.com/facebook/mcrouter.git
 ENV             DEBIAN_FRONTEND         noninteractive
 
-RUN             apt-get update && apt-get install -y git && \
+RUN             apt-get update && apt-get install -y git software-properties-common && \
                 mkdir -p $MCROUTER_DIR/repo && \
                 cd $MCROUTER_DIR/repo && git clone $MCROUTER_REPO && \
                 cd $MCROUTER_DIR/repo/mcrouter/mcrouter/scripts && \


### PR DESCRIPTION
The recipe scripts use the add-apt-repository command, which on Ubuntu 14.04 is provided by the software-properties-common command. Currently, the image fails to build once it hits the installation recipe.