### PR TITLE
Add `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,3 @@
-CONTRIBUTING
-
 # Contributing to Mcrouter
 We want to make contributing to this project as easy and transparent as
 possible.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+CONTRIBUTING
+
+# Contributing to Mcrouter
+We want to make contributing to this project as easy and transparent as
+possible.
+
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
+## Pull Requests
+We actively welcome your pull requests.
+
+1. Fork the repo and create your branch from `master`.
+2. If you've added code that should be tested, add tests.
+3. If you've changed APIs, update the documentation.
+4. Ensure the test suite passes.
+5. Make sure your code lints.
+6. If you haven't already, complete the Contributor License Agreement ("CLA").
+
+## Contributor License Agreement ("CLA")
+In order to accept your pull request, we need you to submit a CLA. You only need
+to do this once to work on any of Facebook's open source projects.
+
+Complete your CLA here: <https://code.facebook.com/cla>
+
+## Issues
+We use GitHub issues to track public bugs. Please ensure your description is
+clear and has sufficient instructions to be able to reproduce the issue.
+
+Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe
+disclosure of security bugs. In those cases, please go through the process
+outlined on that page and do not file a public issue.
+
+## License
+By contributing to Mcrouter, you agree that your contributions will be licensed
+under the LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
In the past there was not info and support to add these docs to all Facebook Open Source projects. It's a useful measure that we can take now to create a healthy, welcoming open source community. :)

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve [the Mcrouter community profile](https://github.com/facebook/mcrouter/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch - 
<img width="1201" alt="screen shot 2017-12-05 at 6 23 01 am" src="https://user-images.githubusercontent.com/1114467/33611918-d6a43a26-d984-11e7-9bf8-8515d71b0158.png">
<img width="1208" alt="screen shot 2017-12-05 at 6 23 19 am" src="https://user-images.githubusercontent.com/1114467/33611920-d7dc2ae8-d984-11e7-9874-539dbb1b0add.png">

**issue:**
internal task t23481323