### PR TITLE
Add Debian 9.3 build scripts.

### DIFF
--- a/mcrouter/m4/ax_boost_context.m4
+++ b/mcrouter/m4/ax_boost_context.m4
@@ -69,13 +69,19 @@ AC_DEFUN([AX_BOOST_CONTEXT],
       CXXFLAGS_SAVE=$CXXFLAGS
 
       AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-        [[@%:@include <boost/context/all.hpp>
-#include <boost/version.hpp>
-]],
-        [[#if BOOST_VERSION >= 105600
-   boost::context::fcontext_t fc = boost::context::make_fcontext(0, 0, 0);
+        [[@%:@include <boost/version.hpp>
+#if BOOST_VERSION >= 106100
+#include <boost/context/detail/fcontext.hpp>
 #else
-   boost::context::fcontext_t* fc = boost::context::make_fcontext(0, 0, 0);
+#include <boost/context/fcontext.hpp>
+#endif
+]],
+        [[#if BOOST_VERSION >= 106100
+  boost::context::detail::fcontext_t fc = boost::context::detail::make_fcontext(0, 0, 0);
+#elif BOOST_VERSION >= 105600
+  boost::context::fcontext_t fc = boost::context::make_fcontext(0, 0, 0);
+#else
+  boost::context::fcontext_t* fc = boost::context::make_fcontext(0, 0, 0);
 #endif
 ]]
         )],
@@ -128,3 +134,4 @@ AC_DEFUN([AX_BOOST_CONTEXT],
     LDFLAGS="$LDFLAGS_SAVED"
   fi
 ])
+

--- a/mcrouter/scripts/install_debian_9.3.sh
+++ b/mcrouter/scripts/install_debian_9.3.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -ex
+
+[ -n "$1" ] || ( echo "Install dir missing"; exit 1 )
+
+sudo apt-get update
+
+sudo apt-get install -y \
+    autoconf \
+    autoconf-archive \
+    automake \
+    binutils-dev \
+    cmake \
+    g++ \
+    gcc \
+    git \
+    googletest \
+    libboost-all-dev \
+    libcap-dev \
+    libdouble-conversion-dev \
+    libdwarf-dev \
+    libelf-dev \
+    libevent-dev \
+    libgflags-dev \
+    libgoogle-glog-dev \
+    libgtest-dev \
+    libiberty-dev \
+    libjemalloc-dev \
+    liblz4-dev \
+    liblzma-dev \
+    libsnappy-dev \
+    libssl-dev \
+    libssl1.0.2 \
+    libtool \
+    libunwind8-dev \
+    make \
+    pkg-config \
+    ragel \
+    scons \
+    sudo \
+    unzip \
+    zlib1g-dev
+
+cd "$(dirname "$0")" || ( echo "cd fail"; exit 1 )
+
+./get_and_build_everything.sh debian-9.3 "$@"

--- a/mcrouter/scripts/order_debian-9.3/10_folly
+++ b/mcrouter/scripts/order_debian-9.3/10_folly
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+if [[ ! -d folly ]]; then
+  git clone https://github.com/facebook/folly
+  cd "$PKG_DIR/folly" || die "cd fail"
+  if [[ -f "$REPO_BASE_DIR/mcrouter/FOLLY_COMMIT" ]]; then
+    FOLLY_COMMIT="$(head -n 1 "$REPO_BASE_DIR/mcrouter/FOLLY_COMMIT")"
+    echo "FOLLY_COMMIT file found: using folly commit $FOLLY_COMMIT"
+    git checkout "$FOLLY_COMMIT"
+  else
+    echo "No FOLLY_COMMIT file, using folly HEAD=$(git rev-parse HEAD)"
+  fi
+fi
+
+if [ ! -d /usr/include/double-conversion ]; then
+    if [ ! -d "$PKG_DIR/double-conversion" ]; then
+        cd "$PKG_DIR" || die "cd fail"
+        git clone https://github.com/google/double-conversion.git
+    fi
+    cd "$PKG_DIR/double-conversion" || die "cd fail"
+
+    # Workaround double-conversion CMakeLists.txt changes that
+    # are incompatible with cmake-2.8
+    git checkout ea970f69edacf66bd3cba2892be284b76e9599b0
+    cmake . -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR"
+    make $MAKE_ARGS && make install $MAKE_ARGS
+
+    export LDFLAGS="-L$INSTALL_DIR/lib -ldl $LDFLAGS"
+    export CPPFLAGS="-I$INSTALL_DIR/include $CPPFLAGS"
+fi
+
+cd "$PKG_DIR/folly/folly/" || die "cd fail"
+
+autoreconf --install
+LD_LIBRARY_PATH="$INSTALL_DIR/lib:$LD_LIBRARY_PATH" \
+    LD_RUN_PATH="$INSTALL_DIR/lib:$LD_RUN_PATH" \
+    ./configure --prefix="$INSTALL_DIR" && \
+    make $MAKE_ARGS && make install $MAKE_ARGS

--- a/mcrouter/scripts/order_debian-9.3/12_wangle
+++ b/mcrouter/scripts/order_debian-9.3/12_wangle
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+if [[ ! -d wangle ]]; then
+  git clone https://github.com/facebook/wangle
+  cd "$PKG_DIR/wangle" || die "cd fail"
+  if [[ -f "$REPO_BASE_DIR/mcrouter/WANGLE_COMMIT" ]]; then
+    WANGLE_COMMIT="$(head -n 1 "$REPO_BASE_DIR/mcrouter/WANGLE_COMMIT")"
+    echo "WANGLE_COMMIT file found: using wangle commit $WANGLE_COMMIT"
+    git checkout "$WANGLE_COMMIT"
+  else
+    echo "No WANGLE_COMMIT file, using wangle HEAD=$(git rev-parse HEAD)"
+  fi
+fi
+
+cd "$PKG_DIR/wangle/wangle/" || die "cd fail"
+
+cmake . -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" -DBUILD_TESTS=OFF
+make $MAKE_ARGS && make install $MAKE_ARGS

--- a/mcrouter/scripts/order_debian-9.3/20_mcrouter
+++ b/mcrouter/scripts/order_debian-9.3/20_mcrouter
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+# clone the latest gtest
+[ -d googletest ] || git clone https://github.com/google/googletest.git
+
+cd "$SCRIPT_DIR/../.." || die "cd fail"
+
+# copy gtest source into lib/gtest folder
+mkdir -p ./lib/gtest
+cp -r -f -t ./lib/gtest "$PKG_DIR/googletest/googletest"/*
+
+autoreconf --install
+LD_LIBRARY_PATH="$INSTALL_DIR/lib:$LD_LIBRARY_PATH" \
+    LD_RUN_PATH="$INSTALL_DIR/lib:$LD_RUN_PATH" \
+    LDFLAGS="-L$INSTALL_DIR/lib $LDFLAGS" \
+    CPPFLAGS="-I$INSTALL_DIR/include $CPPFLAGS" \
+    LIBS=/usr/lib/x86_64-linux-gnu/libssl.so.1.0.2 \
+    ./configure --prefix="$INSTALL_DIR"
+make $MAKE_ARGS && make install $MAKE_ARGS


### PR DESCRIPTION
This also includes @kornrunner's `mcrouter/m4/ax_boost_context.m4` fix for boost 1.61+ from PR #224.