### PR TITLE
Update automake URL CentOS 7 build script

### DIFF
--- a/mcrouter/scripts/install_centos_7.2.sh
+++ b/mcrouter/scripts/install_centos_7.2.sh
@@ -33,7 +33,7 @@ sudo yum install -y \
     ragel
 
 # Install automake-1.15 from Fedora
-sudo rpm -Uvh "http://dl.fedoraproject.org/pub/fedora/linux/releases/23/Everything/x86_64/os/Packages/a/automake-1.15-4.fc23.noarch.rpm"
+yum info automake-1.15-4.fc23 || sudo yum install -y "http://archives.fedoraproject.org/pub/archive/fedora/linux/releases/23/Everything/x86_64/os/Packages/a/automake-1.15-4.fc23.noarch.rpm"
 
 cd "$(dirname "$0")" || ( echo "cd fail"; exit 1 )
 


### PR DESCRIPTION
The previous URL 404s. Additionally, check if automake is already installed before trying to install it again. This means the build script doesn't abort if run a second time.

Fixes https://github.com/facebook/mcrouter/issues/230

cc @khfayzullaev