### PR TITLE
Helps the linker to find libdl and dlopen

### DIFF
--- a/mcrouter/configure.ac
+++ b/mcrouter/configure.ac
@@ -118,6 +118,7 @@ AC_CHECK_HEADER([folly/Likely.h], [], [AC_MSG_ERROR(
 )], [])
 AC_CHECK_LIB([wangle], [getenv], [], [AC_MSG_ERROR(
              [Please install the wangle library])])
+AC_CHECK_LIB([dl], [dlopen], [])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_HEADER_STDBOOL


### PR DESCRIPTION
Needed by Folly in https://github.com/facebook/folly/blob/master/folly/concurrency/CacheLocality.cpp#L212. The linking problem arises when trying to link against a statically compiled Folly library. A Dockerfile reproducing the problem can be found at https://gist.github.com/c4milo/46a35c3c171dc67cfc3e47e460a69dab. This change also fixes #219.