### PR TITLE
Docker - j/Jobs ARG To Reduce Build Time

### DIFF
--- a/mcrouter/scripts/docker/Dockerfile
+++ b/mcrouter/scripts/docker/Dockerfile
@@ -5,12 +5,13 @@ MAINTAINER      mcrouter <mcrouter@fb.com>
 ENV             MCROUTER_DIR            /usr/local/mcrouter
 ENV             MCROUTER_REPO           https://github.com/facebook/mcrouter.git
 ENV             DEBIAN_FRONTEND         noninteractive
+ARG             MAKE_JOBS=1
 
 RUN             apt-get update && apt-get install -y git && \
                 mkdir -p $MCROUTER_DIR/repo && \
                 cd $MCROUTER_DIR/repo && git clone $MCROUTER_REPO && \
                 cd $MCROUTER_DIR/repo/mcrouter/mcrouter/scripts && \
-                ./install_ubuntu_14.04.sh $MCROUTER_DIR && \
+                ./install_ubuntu_14.04.sh $MCROUTER_DIR -j$MAKE_JOBS && \
                 ./clean_ubuntu_14.04.sh $MCROUTER_DIR && rm -rf $MCROUTER_DIR/repo && \
                 ln -s $MCROUTER_DIR/install/bin/mcrouter /usr/local/bin/mcrouter
 


### PR DESCRIPTION
Context: With Docker 1.9+ (since Nov 2015), ARG can be used to
provide build-time arguments.

The mcrouter Dockerfile does not support the ability to provide
a build-time argument for the number of `make` jobs. Why this
matters:

| vCPU | -j arg passed | Time Elapsed |
| --- | --- | --- |
| 2 | none | 27m26.955s |
| 2 | -j2 | 18m20.238s |
| 4 | -j4 | 11m34.981s |

If `-j` is set to the number of vCPUs, the time it takes to build
mcrouter decreases significantly.

```
$ docker build -t mcrouter /home/amcrn/mcrouter/mcrouter/scripts/docker
```

would still default to `-j1`, whereas:

```
$ docker build --build-arg MAKE_JOBS=4 -t mcrouter \
    /home/amcrn/mcrouter/mcrouter/scripts/docker
```

would use `-j4`.

Closes: https://github.com/facebook/mcrouter/issues/97