### PR TITLE
Add duration breakdown for get-like and update-like operations

### DIFF
--- a/mcrouter/ProxyRequestLogger-inl.h
+++ b/mcrouter/ProxyRequestLogger-inl.h
@@ -33,6 +33,12 @@ void ProxyRequestLogger<RouterInfo>::log(
 
   const auto durationUs = loggerContext.endTimeUs - loggerContext.startTimeUs;
   proxy_.stats().durationUs().insertSample(durationUs);
+
+  if (carbon::GetLike<Request>::value) {
+    proxy_.stats().durationGetUs().insertSample(durationUs);
+  } else if (carbon::UpdateLike<Request>::value) {
+    proxy_.stats().durationUpdateUs().insertSample(durationUs);
+  }
 }
 
 #define REQUEST_CLASS_ERROR_STATS(proxy, ERROR, reqClass)     \

--- a/mcrouter/ProxyStats.h
+++ b/mcrouter/ProxyStats.h
@@ -172,9 +172,9 @@ class ProxyStats {
   std::vector<PoolStats> poolStats_;
 
   ExponentialSmoothData<64> durationUs_;
-  //Duration microseconds, broken down by get-like request type
+  // Duration microseconds, broken down by get-like request type
   ExponentialSmoothData<64> durationGetUs_;
-  //Duration microseconds, broken down by update-like request type
+  // Duration microseconds, broken down by update-like request type
   ExponentialSmoothData<64> durationUpdateUs_;
 
   // we are wasting some memory here to get faster mapping from stat name to

--- a/mcrouter/ProxyStats.h
+++ b/mcrouter/ProxyStats.h
@@ -40,6 +40,14 @@ class ProxyStats {
     return durationUs_;
   }
 
+  ExponentialSmoothData<64>& durationGetUs() {
+    return durationGetUs_;
+  }
+
+  ExponentialSmoothData<64>& durationUpdateUs() {
+    return durationUpdateUs_;
+  }
+
   size_t numBinsUsed() const {
     return numBinsUsed_;
   }
@@ -164,6 +172,10 @@ class ProxyStats {
   std::vector<PoolStats> poolStats_;
 
   ExponentialSmoothData<64> durationUs_;
+  //Duration microseconds, broken down by get-like request type
+  ExponentialSmoothData<64> durationGetUs_;
+  //Duration microseconds, broken down by update-like request type
+  ExponentialSmoothData<64> durationUpdateUs_;
 
   // we are wasting some memory here to get faster mapping from stat name to
   // statsBin_[] and statsNumWithinWindow_[] entry. i.e., the statsBin_[]

--- a/mcrouter/stat_list.h
+++ b/mcrouter/stat_list.h
@@ -92,6 +92,11 @@ STUI(fibers_stack_high_watermark, 0, 0)
 //  STUI(failed_client_connections, 0)
 STUI(successful_client_connections, 0, 1)
 STAT(duration_us, stat_double, 0, .dbl = 0.0)
+/**
+ * Duration microseconds, broken down by request type (get-like and update-like).
+ */
+STAT(duration_get_us, stat_double, 0, .dbl = 0.0)
+STAT(duration_update_us, stat_double, 0, .dbl = 0.0)
 #undef GROUP
 #define GROUP ods_stats | mcproxy_stats | max_stats
 STUI(destination_max_pending_reqs, 0, 1)

--- a/mcrouter/stats.cpp
+++ b/mcrouter/stats.cpp
@@ -491,11 +491,15 @@ void prepare_stats(CarbonRouterInstanceBase& router, stat_t* stats) {
         stats[fibers_stack_high_watermark_stat].data.uint64,
         pr->fiberManager().stackHighWatermark());
     stats[duration_us_stat].data.dbl += pr->stats().durationUs().value();
+    stats[duration_get_us_stat].data.dbl += pr->stats().durationGetUs().value();
+    stats[duration_update_us_stat].data.dbl += pr->stats().durationUpdateUs().value();
     stats[client_queue_notify_period_stat].data.dbl += pr->queueNotifyPeriod();
   }
 
   if (router.opts().num_proxies > 0) {
     stats[duration_us_stat].data.dbl /= router.opts().num_proxies;
+    stats[duration_get_us_stat].data.dbl /= router.opts().num_proxies;
+    stats[duration_update_us_stat].data.dbl /= router.opts().num_proxies;
     stats[client_queue_notify_period_stat].data.dbl /=
         router.opts().num_proxies;
   }


### PR DESCRIPTION
This change address a common request that we receive to have separate timing stats between get vs set operations