### PR TITLE
Implement '--listen-addresses=A.B.C.D,...' to bind to a specific set of addresses.

### DIFF
--- a/mcrouter/Server-inl.h
+++ b/mcrouter/Server-inl.h
@@ -86,6 +86,7 @@ bool runServer(
   } else if (!standaloneOpts.unix_domain_sock.empty()) {
     opts.unixDomainSockPath = standaloneOpts.unix_domain_sock;
   } else {
+    opts.listenAddresses = standaloneOpts.listenAddresses;
     opts.ports = standaloneOpts.ports;
     opts.sslPorts = standaloneOpts.ssl_ports;
     opts.tlsTicketKeySeedPath = standaloneOpts.tls_ticket_key_seed_path;

--- a/mcrouter/Server-inl.h
+++ b/mcrouter/Server-inl.h
@@ -86,7 +86,7 @@ bool runServer(
   } else if (!standaloneOpts.unix_domain_sock.empty()) {
     opts.unixDomainSockPath = standaloneOpts.unix_domain_sock;
   } else {
-    opts.listenAddresses = standaloneOpts.listenAddresses;
+    opts.listenAddresses = standaloneOpts.listen_addresses;
     opts.ports = standaloneOpts.ports;
     opts.sslPorts = standaloneOpts.ssl_ports;
     opts.tlsTicketKeySeedPath = standaloneOpts.tls_ticket_key_seed_path;

--- a/mcrouter/lib/network/AsyncMcServer.cpp
+++ b/mcrouter/lib/network/AsyncMcServer.cpp
@@ -370,20 +370,15 @@ class McServerThread {
             socket_->bind(port);
           } else {
             std::vector<folly::IPAddress> ipAddresses;
-            for (auto listenAddress : server_.opts_.listenAddresses) {
+            for (auto& listenAddress : server_.opts_.listenAddresses) {
               auto maybeIp = folly::IPAddress::tryFromString(listenAddress);
               checkLogic(maybeIp.hasValue(),
                          "Invalid listen address: {}",
                          listenAddress);
-              auto ip = maybeIp.value();
-              if (ip.isV4()) {
-                ipAddresses.push_back(ip.asV4());
-              } else if (ip.isV6()) {
-                ipAddresses.push_back(ip.asV6());
-              }
+              auto ip = std::move(maybeIp).value();
+              ipAddresses.push_back(std::move(ip));
             }
 
-            checkLogic(!ipAddresses.empty(), "No valid listen addresses");
             socket_->bind(ipAddresses, port);
           }
         }

--- a/mcrouter/lib/network/AsyncMcServer.cpp
+++ b/mcrouter/lib/network/AsyncMcServer.cpp
@@ -372,8 +372,9 @@ class McServerThread {
             std::vector<folly::IPAddress> ipAddresses;
             for (auto listenAddress : server_.opts_.listenAddresses) {
               auto maybeIp = folly::IPAddress::tryFromString(listenAddress);
-              checkLogic(maybeIp.hasValue(), "Invalid listen address: " +
-                                             "`" + listenAddress + "`");
+              checkLogic(maybeIp.hasValue(),
+                         "Invalid listen address: {}",
+                         listenAddress);
               auto ip = maybeIp.value();
               if (ip.isV4()) {
                 ipAddresses.push_back(ip.asV4());

--- a/mcrouter/lib/network/AsyncMcServer.h
+++ b/mcrouter/lib/network/AsyncMcServer.h
@@ -67,6 +67,12 @@ class AsyncMcServer {
     int tcpListenBacklog{SOMAXCONN};
 
     /**
+     * The list of addresses to listen on.
+     * If this is used, existingSocketFd must be unset (-1).
+     */
+    std::vector<std::string> listenAddresses;
+
+    /**
      * The list of ports to listen on.
      * If this is used, existingSocketFd must be unset (-1).
      */

--- a/mcrouter/options.cpp
+++ b/mcrouter/options.cpp
@@ -123,6 +123,7 @@ string toString(const boost::any& value) {
       tryToString<double>(value, res) || tryToString<bool>(value, res) ||
       tryToString<string>(value, res) ||
       tryToString<vector<uint16_t>>(value, res) ||
+      tryToString<vector<string>>(value, res) ||
       tryToString<mcrouter::RoutingPrefix>(value, res) ||
       tryToString<unordered_map<string, string>>(value, res);
   checkLogic(ok, "Unsupported option type: {}", value.type().name());
@@ -147,6 +148,7 @@ void fromString(const string& str, const boost::any& value) {
       tryFromString<double>(str, value) || tryFromString<bool>(str, value) ||
       tryFromString<string>(str, value) ||
       tryFromString<vector<uint16_t>>(str, value) ||
+      tryFromString<vector<string>>(str, value) ||
       tryFromString<mcrouter::RoutingPrefix>(str, value) ||
       tryFromString<unordered_map<string, string>>(str, value);
 

--- a/mcrouter/standalone_options_list.h
+++ b/mcrouter/standalone_options_list.h
@@ -29,6 +29,14 @@ MCROUTER_OPTION_STRING(
     "Name of the carbon router to use")
 
 MCROUTER_OPTION_OTHER(
+    std::vector<std::string>,
+    listenAddresses,
+    ,
+    "listen-addresses",
+    no_short,
+    "Address(es) to listen on (comma separated)")
+
+MCROUTER_OPTION_OTHER(
     std::vector<uint16_t>,
     ports,
     ,

--- a/mcrouter/standalone_options_list.h
+++ b/mcrouter/standalone_options_list.h
@@ -30,7 +30,7 @@ MCROUTER_OPTION_STRING(
 
 MCROUTER_OPTION_OTHER(
     std::vector<std::string>,
-    listenAddresses,
+    listen_addresses,
     ,
     "listen-addresses",
     no_short,


### PR DESCRIPTION
I've implemented a way to specify which addresses mcrouter should listen on.

This is useful for those of us who like to only run things on loopback or private addresses. :)

The isV4+asV4 / isV6+asV6 are there because folly doesn't set the family field properly for some reason, and I only wanted to touch mcrouter.