### PR TITLE
Fix building errors on Ubuntu 16.04

### DIFF
--- a/mcrouter/Makefile.am
+++ b/mcrouter/Makefile.am
@@ -104,6 +104,7 @@ libmcroutercore_a_SOURCES = \
   routes/BigValueRoute.h \
   routes/BigValueRouteIf.h \
   routes/CarbonLookasideRoute.h \
+  routes/CarbonLookasideRoute.cpp \
   routes/DefaultShadowPolicy.h \
   routes/DestinationRoute.h \
   routes/DevNullRoute.h \

--- a/mcrouter/configure.ac
+++ b/mcrouter/configure.ac
@@ -111,6 +111,7 @@ AC_CHECK_LIB([ssl], [SSL_library_init], [], [AC_MSG_ERROR([Unable to find ssl])]
 AC_CHECK_LIB([z], [gzread], [], [AC_MSG_ERROR([Unable to find zlib])])
 AC_CHECK_LIB([double-conversion],[ceil],[],[AC_MSG_ERROR(
              [Please install double-conversion library])])
+AC_CHECK_LIB([dl], [dlopen], [])
 AC_CHECK_LIB([folly],[getenv],[],[AC_MSG_ERROR(
              [Please install the folly library])])
 AC_CHECK_HEADER([folly/Likely.h], [], [AC_MSG_ERROR(
@@ -118,7 +119,6 @@ AC_CHECK_HEADER([folly/Likely.h], [], [AC_MSG_ERROR(
 )], [])
 AC_CHECK_LIB([wangle], [getenv], [], [AC_MSG_ERROR(
              [Please install the wangle library])])
-AC_CHECK_LIB([dl], [dlopen], [])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_HEADER_STDBOOL

--- a/mcrouter/lib/Makefile.am
+++ b/mcrouter/lib/Makefile.am
@@ -218,4 +218,4 @@ check_PROGRAMS =
 
 libtestmain_la_CPPFLAGS = -Igtest/include -Igtest
 libtestmain_la_SOURCES = TestMain.cpp gtest/src/gtest-all.cc
-libtestmain_la_LIBADD = -lfolly -lfollyinit
+libtestmain_la_LIBADD = -lfolly


### PR DESCRIPTION
Hi friends! Very new at this, but when I tried building mcrouter using the latest version of Folly, I ran into a few issues.

1. libfollyinit.so doesn't seem to be built by default anymore, instead everything is contained within the single libfolly.so. 
2. the library ordering is off since folly depends on dl to be linked.
3. `routes/CarbonLookasideRoute.cpp` was missing from the makefile, which caused a few symbols to be missing.

Let me know what you think, I'd be happy to provide more info if necessary!

@ngoyal @stuclar 