### PR TITLE
Use master branch of facebook/zstd

### DIFF
--- a/mcrouter/scripts/recipes/fbthrift.sh
+++ b/mcrouter/scripts/recipes/fbthrift.sh
@@ -27,7 +27,7 @@ fi
 
 if [ ! -d "$PKG_DIR/zstd" ]; then
   cd "$PKG_DIR" || die "cd fail"
-  git clone https://github.com/facebook/zstd
+  git clone -b master https://github.com/facebook/zstd
 
   cd "$PKG_DIR/zstd" || die "cd fail"
 


### PR DESCRIPTION
At the request of @Cyan4973 in [facebook/zstd/issues/1489](https://github.com/facebook/zstd/issues/1489#issuecomment-451264076), this explicitly sets the `facebook/zstd` checkout branch to `master`.