### PR TITLE
Added rsocket-cpp dependency to Ubuntu 16.04 build script

### DIFF
--- a/mcrouter/scripts/order_ubuntu-16.04/14_rsocket-cpp
+++ b/mcrouter/scripts/order_ubuntu-16.04/14_rsocket-cpp
@@ -1,0 +1,1 @@
+../recipes/rsocket-cpp.sh

--- a/mcrouter/scripts/recipes/rsocket-cpp.sh
+++ b/mcrouter/scripts/recipes/rsocket-cpp.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+if [[ ! -d rsocket-cpp ]]; then
+  git clone https://github.com/rsocket/rsocket-cpp.git
+  cd "$PKG_DIR/rsocket-cpp" || die "cd fail"
+  if [[ -f "$REPO_BASE_DIR/mcrouter/RSOCKETCPP_COMMIT" ]]; then
+    RSOCKETCPP_COMMIT="$(head -n 1 "$REPO_BASE_DIR/mcrouter/RSOCKETCPP_COMMIT")"
+    echo "RSOCKETCPP_COMMIT file found: using rsocket-cpp commit $RSOCKETCPP_COMMIT"
+    git checkout "$RSOCKETCPP_COMMIT"
+  else
+    echo "No RSOCKETCPP_COMMIT file, using rsocket-cpp HEAD=$(git rev-parse HEAD)"
+  fi
+fi
+
+cd "$PKG_DIR/rsocket-cpp/build" || die "cd fail"
+rm -f ../CMakeCache.txt
+
+cmake .. -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" -DBUILD_TESTS=OFF
+make $MAKE_ARGS gmock
+make $MAKE_ARGS && make install $MAKE_ARGS


### PR DESCRIPTION
The Travis build started failing since fbthrift became dependent of rsocket-cpp.
Sample failure: https://travis-ci.org/facebook/mcrouter/builds/489841577
Added a new recipe for rsocket-cpp and included it in the Ubuntu 16.04 scripts.
Test Plan: `./mcrouter/scripts/install_ubuntu_16.04.sh "$(pwd)"/mcrouter-install` succeeded on an Ubuntu 16.04 VM.