### PR TITLE
Improve check for libssl

### DIFF
--- a/mcrouter/configure.ac
+++ b/mcrouter/configure.ac
@@ -118,7 +118,7 @@ AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h netdb.h stdint.h string.h sys/fil
 
 AC_CHECK_LIB([event], [event_set], [], [AC_MSG_ERROR([Unable to find libevent])])
 AC_CHECK_LIB([crypto], [MD5_Init], [], [AC_MSG_ERROR([Unable to find libcrypto])])
-AC_CHECK_LIB([ssl], [SSL_library_init], [], [AC_MSG_ERROR([Unable to find ssl])])
+AC_CHECK_LIB([ssl], [SSL_CTX_new], [], [AC_MSG_ERROR([Unable to find ssl])])
 AC_CHECK_LIB([z], [gzread], [], [AC_MSG_ERROR([Unable to find zlib])])
 AC_CHECK_LIB([double-conversion],[ceil],[],[AC_MSG_ERROR(
              [Please install double-conversion library])])


### PR DESCRIPTION
This improves the check for libssl by checking against SSL_CTX_new instead of SSL_library_init. The latter no longer exists in OpenSSL 1.1.0 and newer. SSL_CTX_new is a universally available function that can be used to check.