### PR TITLE
added some apt-get tweaks

### DIFF
--- a/mcrouter/scripts/clean_ubuntu_14.04.sh
+++ b/mcrouter/scripts/clean_ubuntu_14.04.sh
@@ -6,17 +6,17 @@
 
 set -ex
 
-sudo apt-get install -y libdouble-conversion1 libgflags2 \
+sudo apt-get --no-install-recommends install -y libdouble-conversion1 libgflags2 \
     libboost-program-options1.54.0 libboost-filesystem1.54.0 \
     libboost-system1.54.0 libboost-regex1.54.0 libboost-thread1.54.0 \
     libboost-context1.54.0 libgoogle-glog0 libevent-2.0-5 libjemalloc1
 
-sudo apt-get purge -y gcc g++ ragel autoconf \
+sudo apt-get -purge purge -y gcc g++ ragel autoconf \
     git libtool python-dev libssl-dev libevent-dev \
     binutils-dev make libdouble-conversion-dev libgflags-dev \
     libgoogle-glog-dev libjemalloc-dev
 
-sudo apt-get purge -y 'libboost.*-dev'
+sudo apt-get --purge purge -y 'libboost.*-dev'
 sudo apt-get autoremove --purge -y
 sudo apt-get autoclean -y
 sudo apt-get clean -y

--- a/mcrouter/scripts/docker/Dockerfile
+++ b/mcrouter/scripts/docker/Dockerfile
@@ -6,7 +6,16 @@ ENV             MCROUTER_DIR            /usr/local/mcrouter
 ENV             MCROUTER_REPO           https://github.com/facebook/mcrouter.git
 ENV             DEBIAN_FRONTEND         noninteractive
 
-RUN             apt-get update && apt-get install -y git && \
+RUN             apt-get update && apt-get --no-install-recommends install -y git && \
+                apt-get clean && \
+                apt-get purge autoremove && \
+                rm -rf \
+                      /var/lib/apt/lists/* \
+                      /tmp/* \
+                      /var/tmp/* \
+                      /usr/share/man \
+                      /usr/share/doc \
+                      /usr/share/doc-base && \
                 mkdir -p $MCROUTER_DIR/repo && \
                 cd $MCROUTER_DIR/repo && git clone $MCROUTER_REPO && \
                 cd $MCROUTER_DIR/repo/mcrouter/mcrouter/scripts && \

--- a/mcrouter/scripts/install_ubuntu_14.04.sh
+++ b/mcrouter/scripts/install_ubuntu_14.04.sh
@@ -15,7 +15,7 @@ sudo add-apt-repository -y ppa:sickpig/boost
 
 sudo apt-get update
 
-sudo apt-get install -y \
+sudo apt-get --no-install-recommends install -y \
     autoconf \
     binutils-dev \
     bison \
@@ -58,3 +58,8 @@ export CC="gcc-5"
 export CXX="g++-5"
 
 ./get_and_build_everything.sh ubuntu-14.04 "$@"
+
+# Some Cleanup Up On the go
+sudo apt-get clean
+
+sudo apt-get -y --purge autoremove

--- a/mcrouter/scripts/install_ubuntu_15.04.sh
+++ b/mcrouter/scripts/install_ubuntu_15.04.sh
@@ -10,7 +10,7 @@ set -ex
 
 sudo apt-get update
 
-sudo apt-get install -y \
+sudo apt-get --no-install-recommends install -y \
     autoconf \
     binutils-dev \
     bison \
@@ -41,3 +41,8 @@ sudo apt-get install -y \
 cd "$(dirname "$0")" || ( echo "cd fail"; exit 1 )
 
 ./get_and_build_everything.sh ubuntu-15.04 "$@"
+
+# Some Cleanup Up On the go
+sudo apt-get clean
+
+sudo apt-get -y --purge autoremove

--- a/mcrouter/scripts/install_ubuntu_16.04.sh
+++ b/mcrouter/scripts/install_ubuntu_16.04.sh
@@ -11,7 +11,7 @@ set -ex
 sudo apt-get update
 
 # Note libzstd-dev is not available on stock Ubuntu 14.04 or 15.04.
-sudo apt-get install -y \
+sudo apt-get --no-install-recommends install -y \
     autoconf \
     binutils-dev \
     bison \
@@ -43,3 +43,8 @@ sudo apt-get install -y \
 cd "$(dirname "$0")" || ( echo "cd fail"; exit 1 )
 
 ./get_and_build_everything.sh ubuntu-16.04 "$@"
+
+# Some Cleanup Up On the go
+sudo apt-get clean
+
+sudo apt-get -y --purge autoremove

--- a/mcrouter/scripts/install_ubuntu_18.04.sh
+++ b/mcrouter/scripts/install_ubuntu_18.04.sh
@@ -14,7 +14,7 @@ TARGET="${2:-all}"
 sudo apt-get update
 
 # Note libzstd-dev is not available on stock Ubuntu 14.04 or 15.04.
-sudo apt-get install -y \
+sudo apt-get --no-install-recommends install -y \
     autoconf \
     binutils-dev \
     bison \
@@ -46,3 +46,9 @@ sudo apt-get install -y \
 cd "$(dirname "$0")" || ( echo "cd fail"; exit 1 )
 
 ./get_and_build_by_make.sh "Makefile_ubuntu-18.04" "$TARGET" "$BASE_DIR"
+
+
+# Some Cleanup Up On the go
+sudo apt-get clean
+
+sudo apt-get -y --purge autoremove


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages . 

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Another Cleanup tweaks using 

1. apt-get clean 

2. rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

3. removing packages with "--purge"  will clean the residual configurations of the packages.

removing downloaded packages and packages list will free up some space ,

results in smaller image size in case of docker Image.