### PR TITLE
Fix regression: SSL_CTX_set_security_level and OpenSSL version detection

### DIFF
--- a/mcrouter/lib/network/ThreadLocalSSLContextProvider.cpp
+++ b/mcrouter/lib/network/ThreadLocalSSLContextProvider.cpp
@@ -308,7 +308,7 @@ std::shared_ptr<SSLContext> createClientSSLContext(
   auto context = std::make_shared<ClientSSLContext>(ticketCache.get());
   auto ciphers = folly::ssl::SSLCommonOptions::ciphers();
   std::vector<std::string> cVec(ciphers.begin(), ciphers.end());
-#if FOLLY_OPENSSL_IS_110
+#if FOLLY_OPENSSL_HAS_ALPN
   if (mech == SecurityMech::TLS_TO_PLAINTEXT) {
     // Prepend ECDHE-RSA-NULL-SHA to make it obvious from the ClientHello
     // that we may not be using encryption. For this to work, we must set

--- a/mcrouter/lib/network/ThreadLocalSSLContextProvider.cpp
+++ b/mcrouter/lib/network/ThreadLocalSSLContextProvider.cpp
@@ -317,7 +317,9 @@ std::shared_ptr<SSLContext> createClientSSLContext(
     // ClientHello.
     cVec.insert(cVec.begin(), "ECDHE-RSA-NULL-SHA");
     context->setAdvertisedNextProtocols({kMcSecurityTlsToPlaintextProto.str()});
+#if FOLLY_OPENSSL_IS_110
     SSL_CTX_set_security_level(context->getSSLCtx(), 0);
+#endif
   }
 #endif
   // note we use setCipherSuites instead of setClientOptions since client

--- a/mcrouter/lib/network/ThreadLocalSSLContextProvider.cpp
+++ b/mcrouter/lib/network/ThreadLocalSSLContextProvider.cpp
@@ -308,7 +308,7 @@ std::shared_ptr<SSLContext> createClientSSLContext(
   auto context = std::make_shared<ClientSSLContext>(ticketCache.get());
   auto ciphers = folly::ssl::SSLCommonOptions::ciphers();
   std::vector<std::string> cVec(ciphers.begin(), ciphers.end());
-#if FOLLY_OPENSSL_HAS_ALPN
+#if FOLLY_OPENSSL_IS_110
   if (mech == SecurityMech::TLS_TO_PLAINTEXT) {
     // Prepend ECDHE-RSA-NULL-SHA to make it obvious from the ClientHello
     // that we may not be using encryption. For this to work, we must set


### PR DESCRIPTION
This fixes a compilation regression recently introduced by D22433603 (OSS e1a06dc0f70a6b9e27c5b9179427804054613806) when compiling under OpenSSL >= 1.0.2 but <= 1.1.0.

`SSL_CTX_set_security_level` was first introduced in OpenSSL 1.1.0 per its manpage, but the compile guard `FOLLY_OPENSSL_HAS_ALPN` only checks for OpenSSL >= 1.0.2.

Ref:
https://github.com/facebook/folly/blob/b1d264ed8e7ee445f157a7ad7493b99f916eb6df/folly/portability/OpenSSL.h#L62
https://github.com/facebook/folly/blob/b1d264ed8e7ee445f157a7ad7493b99f916eb6df/folly/portability/OpenSSL.h#L88