### PR TITLE
Fix OSS build: -lrpcmetadata to accommodate fbthrift change

### DIFF
--- a/mcrouter/Makefile.am
+++ b/mcrouter/Makefile.am
@@ -230,6 +230,7 @@ mcrouter_LDADD = \
   -lthriftcpp2 \
   -ltransport \
   -lthriftprotocol \
+  -lrpcmetadata \
   -lasync \
   -lconcurrency \
   -lprotocol \

--- a/mcrouter/lib/network/Makefile.am
+++ b/mcrouter/lib/network/Makefile.am
@@ -15,6 +15,7 @@ mock_mc_server_LDADD = \
 	-lthriftcpp2 \
 	-ltransport \
 	-lthriftprotocol \
+	-lrpcmetadata \
 	-lasync \
 	-lconcurrency \
 	-lprotocol \
@@ -36,6 +37,7 @@ mock_mc_thrift_server_LDADD = \
 	-lthriftcpp2 \
 	-ltransport \
 	-lthriftprotocol \
+	-lrpcmetadata \
 	-lasync \
 	-lconcurrency \
 	-lprotocol \
@@ -57,6 +59,7 @@ mock_mc_server_dual_LDADD = \
 	-lthriftcpp2 \
 	-ltransport \
 	-lthriftprotocol \
+	-lrpcmetadata \
 	-lasync \
 	-lconcurrency \
 	-lprotocol \

--- a/mcrouter/lib/network/test/Makefile.am
+++ b/mcrouter/lib/network/test/Makefile.am
@@ -31,6 +31,7 @@ mcrouter_network_test_LDADD = \
   -lprotocol \
   -lthriftcpp2 \
   -lthriftprotocol \
+  -lrpcmetadata \
   -ltransport \
   -lwangle \
   -lfizz \

--- a/mcrouter/tools/mcpiper/Makefile.am
+++ b/mcrouter/tools/mcpiper/Makefile.am
@@ -34,6 +34,7 @@ mcpiper_LDADD = \
 	-lprotocol \
 	-lthriftcpp2 \
 	-lthriftprotocol \
+	-lrpcmetadata \
 	-ltransport \
 	-lthrift-core \
 	-lfizz \


### PR DESCRIPTION
fbthrift commit https://github.com/facebook/fbthrift/commit/0d079b3ca4943f86268a81a1a8b50e757b37e495 broke mcrouter OSS compilation by introducing a new `rpcmetadata` library target, which causes mcrouter build to fail e.g. https://travis-ci.org/github/facebook/mcrouter/jobs/713583896

<details>
    <summary>mcrouter build error symptom</summary>

    ```
    /bin/bash ./libtool  --tag=CXX   --mode=link g++  -DLIBMC_FBTRACE_DISABLE -DDISABLE_COMPRESSION  -Wno-missing-field-initializers -Wno-deprecated -W -Wall -Wextra -Wno-unused-parameter -fno-strict-aliasing -g -O2  -L/home/travis/build/facebook/mcrouter/mcrouter-install/install/lib -ljemalloc  -o mcrouter mcrouter-main.o mcrouter-StandaloneConfig.o mcrouter-StandaloneUtils.o libmcroutercore.a lib/libmcrouter.a -lthriftcpp2 -ltransport -lthriftprotocol -lasync -lconcurrency -lprotocol -lthrift-core -lfmt -lwangle -lfolly -lfizz -lsodium -lfolly -ldl -ldouble-conversion -lz -lssl -lcrypto -levent -lgflags -lglog  -L/usr/lib/x86_64-linux-gnu -lboost_context -lboost_filesystem       -lboost_program_options -lboost_system -lboost_regex       -lboost_thread -lpthread -pthread -ldl -lunwind       -lbz2 -llz4 -llzma -lsnappy -lzstd

    libtool: link: g++ -DLIBMC_FBTRACE_DISABLE -DDISABLE_COMPRESSION -Wno-missing-field-initializers -Wno-deprecated -W -Wall -Wextra -Wno-unused-parameter -fno-strict-aliasing -g -O2 -o mcrouter mcrouter-main.o mcrouter-StandaloneConfig.o mcrouter-StandaloneUtils.o -pthread  -L/home/travis/build/facebook/mcrouter/mcrouter-install/install/lib -ljemalloc libmcroutercore.a lib/libmcrouter.a -lthriftcpp2 -ltransport -lthriftprotocol -lasync -lconcurrency -lprotocol -lthrift-core -lfmt -lwangle -lfizz -lsodium -lfolly -ldouble-conversion -lz -lssl -lcrypto -levent -lgflags -lglog -L/usr/lib/x86_64-linux-gnu -lboost_context -lboost_filesystem -lboost_program_options -lboost_system -lboost_regex -lboost_thread -lpthread -ldl -lunwind -lbz2 -llz4 -llzma -lsnappy -lzstd -pthread

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): In function `apache::thrift::(anonymous namespace)::decodeResponseError(apache::thrift::rocket::RocketException&&, unsigned short, folly::Range<char const*>)':

    RocketClientChannel.cpp:(.text+0x5fd): undefined reference to `apache::thrift::ResponseRpcError::ResponseRpcError()'

    RocketClientChannel.cpp:(.text+0x8db): undefined reference to `apache::thrift::ResponseRpcMetadata::ResponseRpcMetadata()'

    RocketClientChannel.cpp:(.text+0xe8a): undefined reference to `apache::thrift::ResponseRpcMetadata::~ResponseRpcMetadata()'

    RocketClientChannel.cpp:(.text+0xe99): undefined reference to `apache::thrift::ResponseRpcMetadata::~ResponseRpcMetadata()'

    RocketClientChannel.cpp:(.text+0xeb7): undefined reference to `apache::thrift::ResponseRpcError::~ResponseRpcError()'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): In function `apache::thrift::RocketClientChannel::makeSetupFrame(apache::thrift::RequestSetupMetadata)':

    RocketClientChannel.cpp:(.text+0x3abb): undefined reference to `unsigned int apache::thrift::RequestSetupMetadata::write<apache::thrift::CompactProtocolWriter>(apache::thrift::CompactProtocolWriter*) const'

    RocketClientChannel.cpp:(.text+0x3ad4): undefined reference to `unsigned int apache::thrift::RequestSetupMetadata::serializedSize<apache::thrift::CompactProtocolWriter>(apache::thrift::CompactProtocolWriter const*) const'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): In function `apache::thrift::RocketClientChannel::sendRequestStream(apache::thrift::RpcOptions const&, folly::Range<char const*>, apache::thrift::SerializedRequest&&, std::shared_ptr<apache::thrift::transport::THeader>, apache::thrift::StreamClientCallback*)':

    RocketClientChannel.cpp:(.text+0x4bd0): undefined reference to `apache::thrift::RequestRpcMetadata::~RequestRpcMetadata()'

    RocketClientChannel.cpp:(.text+0x4c3f): undefined reference to `apache::thrift::RequestRpcMetadata::~RequestRpcMetadata()'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): In function `apache::thrift::RocketClientChannel::sendRequestSink(apache::thrift::RpcOptions const&, folly::Range<char const*>, apache::thrift::SerializedRequest&&, std::shared_ptr<apache::thrift::transport::THeader>, apache::thrift::SinkClientCallback*)':

    RocketClientChannel.cpp:(.text+0x4f4f): undefined reference to `apache::thrift::RequestRpcMetadata::~RequestRpcMetadata()'

    RocketClientChannel.cpp:(.text+0x4fd9): undefined reference to `apache::thrift::RequestRpcMetadata::~RequestRpcMetadata()'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): In function `apache::thrift::RocketClientChannel::sendThriftRequest(apache::thrift::RpcOptions const&, apache::thrift::RpcKind, folly::Range<char const*>, apache::thrift::SerializedRequest&&, std::shared_ptr<apache::thrift::transport::THeader>, std::unique_ptr<apache::thrift::RequestClientCallback, apache::thrift::RequestClientCallback::RequestClientCallbackDeleter>)':

    RocketClientChannel.cpp:(.text+0x539a): undefined reference to `apache::thrift::RequestRpcMetadata::~RequestRpcMetadata()'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClientChannel.cpp.o):RocketClientChannel.cpp:(.text+0x5452): more undefined references to `apache::thrift::RequestRpcMetadata::~RequestRpcMetadata()' follow

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): In function `apache::thrift::CodecConfig::~CodecConfig()':

    RocketClientChannel.cpp:(.text._ZN6apache6thrift11CodecConfigD2Ev[_ZN6apache6thrift11CodecConfigD5Ev]+0x14): undefined reference to `apache::thrift::CodecConfig::__clear()'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): In function `apache::thrift::CodecConfig::set_zlibConfig(apache::thrift::ZlibCompressionCodecConfig const&)':

    RocketClientChannel.cpp:(.text._ZN6apache6thrift11CodecConfig14set_zlibConfigERKNS0_26ZlibCompressionCodecConfigE[_ZN6apache6thrift11CodecConfig14set_zlibConfigERKNS0_26ZlibCompressionCodecConfigE]+0x18): undefined reference to `apache::thrift::CodecConfig::__clear()'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): In function `apache::thrift::CodecConfig::set_zstdConfig(apache::thrift::ZstdCompressionCodecConfig const&)':

    RocketClientChannel.cpp:(.text._ZN6apache6thrift11CodecConfig14set_zstdConfigERKNS0_26ZstdCompressionCodecConfigE[_ZN6apache6thrift11CodecConfig14set_zstdConfigERKNS0_26ZstdCompressionCodecConfigE]+0x18): undefined reference to `apache::thrift::CodecConfig::__clear()'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): In function `apache::thrift::PayloadExceptionMetadata::PayloadExceptionMetadata(apache::thrift::PayloadExceptionMetadata&&)':

    RocketClientChannel.cpp:(.text._ZN6apache6thrift24PayloadExceptionMetadataC2EOS1_[_ZN6apache6thrift24PayloadExceptionMetadataC5EOS1_]+0x15a): undefined reference to `apache::thrift::PayloadExceptionMetadata::__clear()'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): In function `apache::thrift::PayloadExceptionMetadata::set_declaredException(apache::thrift::PayloadDeclaredExceptionMetadata&&)':

    RocketClientChannel.cpp:(.text._ZN6apache6thrift24PayloadExceptionMetadata21set_declaredExceptionEONS0_32PayloadDeclaredExceptionMetadataE[_ZN6apache6thrift24PayloadExceptionMetadata21set_declaredExceptionEONS0_32PayloadDeclaredExceptionMetadataE]+0x18): undefined reference to `apache::thrift::PayloadExceptionMetadata::__clear()'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): In function `apache::thrift::PayloadExceptionMetadata::set_proxyException(apache::thrift::PayloadProxyExceptionMetadata&&)':

    RocketClientChannel.cpp:(.text._ZN6apache6thrift24PayloadExceptionMetadata18set_proxyExceptionEONS0_29PayloadProxyExceptionMetadataE[_ZN6apache6thrift24PayloadExceptionMetadata18set_proxyExceptionEONS0_29PayloadProxyExceptionMetadataE]+0x18): undefined reference to `apache::thrift::PayloadExceptionMetadata::__clear()'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): In function `apache::thrift::PayloadExceptionMetadata::set_proxiedException(apache::thrift::PayloadProxiedExceptionMetadata&&)':

    RocketClientChannel.cpp:(.text._ZN6apache6thrift24PayloadExceptionMetadata20set_proxiedExceptionEONS0_31PayloadProxiedExceptionMetadataE[_ZN6apache6thrift24PayloadExceptionMetadata20set_proxiedExceptionEONS0_31PayloadProxiedExceptionMetadataE]+0x18): undefined reference to `apache::thrift::PayloadExceptionMetadata::__clear()'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): In function `apache::thrift::PayloadExceptionMetadata::set_appClientException(apache::thrift::PayloadAppClientExceptionMetadata&&)':

    RocketClientChannel.cpp:(.text._ZN6apache6thrift24PayloadExceptionMetadata22set_appClientExceptionEONS0_33PayloadAppClientExceptionMetadataE[_ZN6apache6thrift24PayloadExceptionMetadata22set_appClientExceptionEONS0_33PayloadAppClientExceptionMetadataE]+0x18): undefined reference to `apache::thrift::PayloadExceptionMetadata::__clear()'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClientChannel.cpp.o):RocketClientChannel.cpp:(.text._ZN6apache6thrift24PayloadExceptionMetadata22set_appServerExceptionEONS0_33PayloadAppServerExceptionMetadataE[_ZN6apache6thrift24PayloadExceptionMetadata22set_appServerExceptionEONS0_33PayloadAppServerExceptionMetadataE]+0x18): more undefined references to `apache::thrift::PayloadExceptionMetadata::__clear()' follow

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): In function `apache::thrift::PayloadMetadata::PayloadMetadata(apache::thrift::PayloadMetadata&&)':

    RocketClientChannel.cpp:(.text._ZN6apache6thrift15PayloadMetadataC2EOS1_[_ZN6apache6thrift15PayloadMetadataC5EOS1_]+0xc8): undefined reference to `apache::thrift::PayloadMetadata::__clear()'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): In function `apache::thrift::PayloadMetadata::set_responseMetadata(apache::thrift::PayloadResponseMetadata&&)':

    RocketClientChannel.cpp:(.text._ZN6apache6thrift15PayloadMetadata20set_responseMetadataEONS0_23PayloadResponseMetadataE[_ZN6apache6thrift15PayloadMetadata20set_responseMetadataEONS0_23PayloadResponseMetadataE]+0x18): undefined reference to `apache::thrift::PayloadMetadata::__clear()'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): In function `apache::thrift::PayloadMetadata::set_exceptionMetadata(apache::thrift::PayloadExceptionMetadataBase&&)':

    RocketClientChannel.cpp:(.text._ZN6apache6thrift15PayloadMetadata21set_exceptionMetadataEONS0_28PayloadExceptionMetadataBaseE[_ZN6apache6thrift15PayloadMetadata21set_exceptionMetadataEONS0_28PayloadExceptionMetadataBaseE]+0x1d): undefined reference to `apache::thrift::PayloadMetadata::__clear()'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): In function `apache::thrift::FirstResponsePayload::~FirstResponsePayload()':

    RocketClientChannel.cpp:(.text._ZN6apache6thrift20FirstResponsePayloadD2Ev[_ZN6apache6thrift20FirstResponsePayloadD5Ev]+0x18): undefined reference to `apache::thrift::ResponseRpcMetadata::~ResponseRpcMetadata()'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): In function `apache::thrift::rocket::unpack<apache::thrift::FirstResponsePayload>(apache::thrift::rocket::Payload&&)::{lambda()#1}::operator()() const':

    RocketClientChannel.cpp:(.text._ZZN6apache6thrift6rocket6unpackINS0_20FirstResponsePayloadEEEN5folly3TryIT_EEONS1_7PayloadEENKUlvE_clEv[_ZZN6apache6thrift6rocket6unpackINS0_20FirstResponsePayloadEEEN5folly3TryIT_EEONS1_7PayloadEENKUlvE_clEv]+0x43): undefined reference to `apache::thrift::ResponseRpcMetadata::ResponseRpcMetadata()'

    RocketClientChannel.cpp:(.text._ZZN6apache6thrift6rocket6unpackINS0_20FirstResponsePayloadEEEN5folly3TryIT_EEONS1_7PayloadEENKUlvE_clEv[_ZZN6apache6thrift6rocket6unpackINS0_20FirstResponsePayloadEEEN5folly3TryIT_EEONS1_7PayloadEENKUlvE_clEv]+0x72): undefined reference to `apache::thrift::ResponseRpcMetadata::~ResponseRpcMetadata()'

    RocketClientChannel.cpp:(.text._ZZN6apache6thrift6rocket6unpackINS0_20FirstResponsePayloadEEEN5folly3TryIT_EEONS1_7PayloadEENKUlvE_clEv[_ZZN6apache6thrift6rocket6unpackINS0_20FirstResponsePayloadEEEN5folly3TryIT_EEONS1_7PayloadEENKUlvE_clEv]+0x434): undefined reference to `apache::thrift::ResponseRpcMetadata::~ResponseRpcMetadata()'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): In function `unsigned int apache::thrift::ResponseRpcError::read<apache::thrift::CompactProtocolReader>(apache::thrift::CompactProtocolReader*)':

    RocketClientChannel.cpp:(.text._ZN6apache6thrift16ResponseRpcError4readINS0_21CompactProtocolReaderEEEjPT_[_ZN6apache6thrift16ResponseRpcError4readINS0_21CompactProtocolReaderEEEjPT_]+0x2f): undefined reference to `void apache::thrift::ResponseRpcError::readNoXfer<apache::thrift::CompactProtocolReader>(apache::thrift::CompactProtocolReader*)'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): In function `unsigned int apache::thrift::ResponseRpcMetadata::read<apache::thrift::CompactProtocolReader>(apache::thrift::CompactProtocolReader*)':

    RocketClientChannel.cpp:(.text._ZN6apache6thrift19ResponseRpcMetadata4readINS0_21CompactProtocolReaderEEEjPT_[_ZN6apache6thrift19ResponseRpcMetadata4readINS0_21CompactProtocolReaderEEEjPT_]+0x2f): undefined reference to `void apache::thrift::ResponseRpcMetadata::readNoXfer<apache::thrift::CompactProtocolReader>(apache::thrift::CompactProtocolReader*)'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RpcMetadataUtil.cpp.o): In function `apache::thrift::detail::makeRequestRpcMetadata(apache::thrift::RpcOptions const&, apache::thrift::RpcKind, apache::thrift::ProtocolId, folly::Range<char const*>, std::chrono::duration<long, std::ratio<1l, 1000l> >, apache::thrift::transport::THeader&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&)':

    RpcMetadataUtil.cpp:(.text+0x64): undefined reference to `apache::thrift::RequestRpcMetadata::RequestRpcMetadata()'

    RpcMetadataUtil.cpp:(.text+0xbe6): undefined reference to `apache::thrift::RequestRpcMetadata::~RequestRpcMetadata()'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RpcMetadataUtil.cpp.o): In function `apache::thrift::CodecConfig::operator=(apache::thrift::CodecConfig const&)':

    RpcMetadataUtil.cpp:(.text._ZN6apache6thrift11CodecConfigaSERKS1_[_ZN6apache6thrift11CodecConfigaSERKS1_]+0x2b): undefined reference to `apache::thrift::CodecConfig::__clear()'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(PayloadUtils.cpp.o): In function `apache::thrift::rocket::Payload apache::thrift::rocket::detail::makePayload<apache::thrift::RequestRpcMetadata>(apache::thrift::RequestRpcMetadata const&, std::unique_ptr<folly::IOBuf, std::default_delete<folly::IOBuf> >)':

    PayloadUtils.cpp:(.text._ZN6apache6thrift6rocket6detail11makePayloadINS0_18RequestRpcMetadataEEENS1_7PayloadERKT_St10unique_ptrIN5folly5IOBufESt14default_deleteISB_EE[_ZN6apache6thrift6rocket6detail11makePayloadINS0_18RequestRpcMetadataEEENS1_7PayloadERKT_St10unique_ptrIN5folly5IOBufESt14default_deleteISB_EE]+0x5b): undefined reference to `unsigned int apache::thrift::RequestRpcMetadata::serializedSizeZC<apache::thrift::CompactProtocolWriter>(apache::thrift::CompactProtocolWriter const*) const'

    PayloadUtils.cpp:(.text._ZN6apache6thrift6rocket6detail11makePayloadINS0_18RequestRpcMetadataEEENS1_7PayloadERKT_St10unique_ptrIN5folly5IOBufESt14default_deleteISB_EE[_ZN6apache6thrift6rocket6detail11makePayloadINS0_18RequestRpcMetadataEEENS1_7PayloadERKT_St10unique_ptrIN5folly5IOBufESt14default_deleteISB_EE]+0x236): undefined reference to `unsigned int apache::thrift::RequestRpcMetadata::write<apache::thrift::CompactProtocolWriter>(apache::thrift::CompactProtocolWriter*) const'

    PayloadUtils.cpp:(.text._ZN6apache6thrift6rocket6detail11makePayloadINS0_18RequestRpcMetadataEEENS1_7PayloadERKT_St10unique_ptrIN5folly5IOBufESt14default_deleteISB_EE[_ZN6apache6thrift6rocket6detail11makePayloadINS0_18RequestRpcMetadataEEENS1_7PayloadERKT_St10unique_ptrIN5folly5IOBufESt14default_deleteISB_EE]+0x406): undefined reference to `unsigned int apache::thrift::RequestRpcMetadata::write<apache::thrift::CompactProtocolWriter>(apache::thrift::CompactProtocolWriter*) const'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(PayloadUtils.cpp.o): In function `apache::thrift::rocket::Payload apache::thrift::rocket::detail::makePayload<apache::thrift::ResponseRpcMetadata>(apache::thrift::ResponseRpcMetadata const&, std::unique_ptr<folly::IOBuf, std::default_delete<folly::IOBuf> >)':

    PayloadUtils.cpp:(.text._ZN6apache6thrift6rocket6detail11makePayloadINS0_19ResponseRpcMetadataEEENS1_7PayloadERKT_St10unique_ptrIN5folly5IOBufESt14default_deleteISB_EE[_ZN6apache6thrift6rocket6detail11makePayloadINS0_19ResponseRpcMetadataEEENS1_7PayloadERKT_St10unique_ptrIN5folly5IOBufESt14default_deleteISB_EE]+0x5b): undefined reference to `unsigned int apache::thrift::ResponseRpcMetadata::serializedSizeZC<apache::thrift::CompactProtocolWriter>(apache::thrift::CompactProtocolWriter const*) const'

    PayloadUtils.cpp:(.text._ZN6apache6thrift6rocket6detail11makePayloadINS0_19ResponseRpcMetadataEEENS1_7PayloadERKT_St10unique_ptrIN5folly5IOBufESt14default_deleteISB_EE[_ZN6apache6thrift6rocket6detail11makePayloadINS0_19ResponseRpcMetadataEEENS1_7PayloadERKT_St10unique_ptrIN5folly5IOBufESt14default_deleteISB_EE]+0x236): undefined reference to `unsigned int apache::thrift::ResponseRpcMetadata::write<apache::thrift::CompactProtocolWriter>(apache::thrift::CompactProtocolWriter*) const'

    PayloadUtils.cpp:(.text._ZN6apache6thrift6rocket6detail11makePayloadINS0_19ResponseRpcMetadataEEENS1_7PayloadERKT_St10unique_ptrIN5folly5IOBufESt14default_deleteISB_EE[_ZN6apache6thrift6rocket6detail11makePayloadINS0_19ResponseRpcMetadataEEENS1_7PayloadERKT_St10unique_ptrIN5folly5IOBufESt14default_deleteISB_EE]+0x406): undefined reference to `unsigned int apache::thrift::ResponseRpcMetadata::write<apache::thrift::CompactProtocolWriter>(apache::thrift::CompactProtocolWriter*) const'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(PayloadUtils.cpp.o): In function `apache::thrift::rocket::Payload apache::thrift::rocket::detail::makePayload<apache::thrift::StreamPayloadMetadata>(apache::thrift::StreamPayloadMetadata const&, std::unique_ptr<folly::IOBuf, std::default_delete<folly::IOBuf> >)':

    PayloadUtils.cpp:(.text._ZN6apache6thrift6rocket6detail11makePayloadINS0_21StreamPayloadMetadataEEENS1_7PayloadERKT_St10unique_ptrIN5folly5IOBufESt14default_deleteISB_EE[_ZN6apache6thrift6rocket6detail11makePayloadINS0_21StreamPayloadMetadataEEENS1_7PayloadERKT_St10unique_ptrIN5folly5IOBufESt14default_deleteISB_EE]+0x5b): undefined reference to `unsigned int apache::thrift::StreamPayloadMetadata::serializedSizeZC<apache::thrift::CompactProtocolWriter>(apache::thrift::CompactProtocolWriter const*) const'

    PayloadUtils.cpp:(.text._ZN6apache6thrift6rocket6detail11makePayloadINS0_21StreamPayloadMetadataEEENS1_7PayloadERKT_St10unique_ptrIN5folly5IOBufESt14default_deleteISB_EE[_ZN6apache6thrift6rocket6detail11makePayloadINS0_21StreamPayloadMetadataEEENS1_7PayloadERKT_St10unique_ptrIN5folly5IOBufESt14default_deleteISB_EE]+0x236): undefined reference to `unsigned int apache::thrift::StreamPayloadMetadata::write<apache::thrift::CompactProtocolWriter>(apache::thrift::CompactProtocolWriter*) const'

    PayloadUtils.cpp:(.text._ZN6apache6thrift6rocket6detail11makePayloadINS0_21StreamPayloadMetadataEEENS1_7PayloadERKT_St10unique_ptrIN5folly5IOBufESt14default_deleteISB_EE[_ZN6apache6thrift6rocket6detail11makePayloadINS0_21StreamPayloadMetadataEEENS1_7PayloadERKT_St10unique_ptrIN5folly5IOBufESt14default_deleteISB_EE]+0x406): undefined reference to `unsigned int apache::thrift::StreamPayloadMetadata::write<apache::thrift::CompactProtocolWriter>(apache::thrift::CompactProtocolWriter*) const'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(PayloadUtils.cpp.o): In function `apache::thrift::rocket::Payload apache::thrift::rocket::detail::makePayload<apache::thrift::HeadersPayloadMetadata>(apache::thrift::HeadersPayloadMetadata const&, std::unique_ptr<folly::IOBuf, std::default_delete<folly::IOBuf> >)':

    PayloadUtils.cpp:(.text._ZN6apache6thrift6rocket6detail11makePayloadINS0_22HeadersPayloadMetadataEEENS1_7PayloadERKT_St10unique_ptrIN5folly5IOBufESt14default_deleteISB_EE[_ZN6apache6thrift6rocket6detail11makePayloadINS0_22HeadersPayloadMetadataEEENS1_7PayloadERKT_St10unique_ptrIN5folly5IOBufESt14default_deleteISB_EE]+0x5b): undefined reference to `unsigned int apache::thrift::HeadersPayloadMetadata::serializedSizeZC<apache::thrift::CompactProtocolWriter>(apache::thrift::CompactProtocolWriter const*) const'

    PayloadUtils.cpp:(.text._ZN6apache6thrift6rocket6detail11makePayloadINS0_22HeadersPayloadMetadataEEENS1_7PayloadERKT_St10unique_ptrIN5folly5IOBufESt14default_deleteISB_EE[_ZN6apache6thrift6rocket6detail11makePayloadINS0_22HeadersPayloadMetadataEEENS1_7PayloadERKT_St10unique_ptrIN5folly5IOBufESt14default_deleteISB_EE]+0x236): undefined reference to `unsigned int apache::thrift::HeadersPayloadMetadata::write<apache::thrift::CompactProtocolWriter>(apache::thrift::CompactProtocolWriter*) const'

    PayloadUtils.cpp:(.text._ZN6apache6thrift6rocket6detail11makePayloadINS0_22HeadersPayloadMetadataEEENS1_7PayloadERKT_St10unique_ptrIN5folly5IOBufESt14default_deleteISB_EE[_ZN6apache6thrift6rocket6detail11makePayloadINS0_22HeadersPayloadMetadataEEENS1_7PayloadERKT_St10unique_ptrIN5folly5IOBufESt14default_deleteISB_EE]+0x406): undefined reference to `unsigned int apache::thrift::HeadersPayloadMetadata::write<apache::thrift::CompactProtocolWriter>(apache::thrift::CompactProtocolWriter*) const'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClient.cpp.o): In function `std::unique_ptr<folly::IOBuf, std::default_delete<folly::IOBuf> > apache::thrift::rocket::packCompact<apache::thrift::InteractionTerminate>(apache::thrift::InteractionTerminate&&)':

    RocketClient.cpp:(.text._ZN6apache6thrift6rocket11packCompactINS0_20InteractionTerminateEEESt10unique_ptrIN5folly5IOBufESt14default_deleteIS6_EEOT_[_ZN6apache6thrift6rocket11packCompactINS0_20InteractionTerminateEEESt10unique_ptrIN5folly5IOBufESt14default_deleteIS6_EEOT_]+0x9b): undefined reference to `unsigned int apache::thrift::InteractionTerminate::write<apache::thrift::CompactProtocolWriter>(apache::thrift::CompactProtocolWriter*) const'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClient.cpp.o): In function `std::unique_ptr<folly::IOBuf, std::default_delete<folly::IOBuf> > apache::thrift::rocket::packCompact<apache::thrift::HeadersPayloadContent>(apache::thrift::HeadersPayloadContent&&)':

    RocketClient.cpp:(.text._ZN6apache6thrift6rocket11packCompactINS0_21HeadersPayloadContentEEESt10unique_ptrIN5folly5IOBufESt14default_deleteIS6_EEOT_[_ZN6apache6thrift6rocket11packCompactINS0_21HeadersPayloadContentEEESt10unique_ptrIN5folly5IOBufESt14default_deleteIS6_EEOT_]+0x9b): undefined reference to `unsigned int apache::thrift::HeadersPayloadContent::write<apache::thrift::CompactProtocolWriter>(apache::thrift::CompactProtocolWriter*) const'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClient.cpp.o): In function `unsigned int apache::thrift::StreamPayloadMetadata::read<apache::thrift::CompactProtocolReader>(apache::thrift::CompactProtocolReader*)':

    RocketClient.cpp:(.text._ZN6apache6thrift21StreamPayloadMetadata4readINS0_21CompactProtocolReaderEEEjPT_[_ZN6apache6thrift21StreamPayloadMetadata4readINS0_21CompactProtocolReaderEEEjPT_]+0x2f): undefined reference to `void apache::thrift::StreamPayloadMetadata::readNoXfer<apache::thrift::CompactProtocolReader>(apache::thrift::CompactProtocolReader*)'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClient.cpp.o): In function `unsigned int apache::thrift::HeadersPayloadMetadata::read<apache::thrift::CompactProtocolReader>(apache::thrift::CompactProtocolReader*)':

    RocketClient.cpp:(.text._ZN6apache6thrift22HeadersPayloadMetadata4readINS0_21CompactProtocolReaderEEEjPT_[_ZN6apache6thrift22HeadersPayloadMetadata4readINS0_21CompactProtocolReaderEEEjPT_]+0x2f): undefined reference to `void apache::thrift::HeadersPayloadMetadata::readNoXfer<apache::thrift::CompactProtocolReader>(apache::thrift::CompactProtocolReader*)'

    /home/travis/build/facebook/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(RocketClient.cpp.o): In function `unsigned int apache::thrift::HeadersPayloadContent::read<apache::thrift::CompactProtocolReader>(apache::thrift::CompactProtocolReader*)':

    RocketClient.cpp:(.text._ZN6apache6thrift21HeadersPayloadContent4readINS0_21CompactProtocolReaderEEEjPT_[_ZN6apache6thrift21HeadersPayloadContent4readINS0_21CompactProtocolReaderEEEjPT_]+0x2f): undefined reference to `void apache::thrift::HeadersPayloadContent::readNoXfer<apache::thrift::CompactProtocolReader>(apache::thrift::CompactProtocolReader*)'

    collect2: error: ld returned 1 exit status
    ```
</details>

This change adds `-lrpcmetadata` to `LDADD` where relevant.