### PR TITLE
Define mcpiper version string at configuration time

### DIFF
--- a/mcrouter/configure.ac
+++ b/mcrouter/configure.ac
@@ -7,6 +7,7 @@ m4_define([mcrouter_version_suffix], m4_esyscmd_s([sed 's/^[0-9]*:[0-9]*//' VERS
 m4_define([mcrouter_version], m4_translit(mcrouter_version_str, [:], [.]))
 m4_append([mcrouter_version], [.0])
 m4_append([mcrouter_version], [mcrouter_version_suffix])
+m4_define([mcpiper_version], [1.0])
 AC_INIT([mcrouter], [mcrouter_version], mcrouter@fb.com)
 
 AC_ARG_VAR([FBTHRIFT_BIN], [Path to FBThrift compiler])
@@ -20,6 +21,7 @@ AC_SUBST([FBTHRIFT])
 
 
 AC_DEFINE_UNQUOTED([MCROUTER_PACKAGE_STRING], ["AC_PACKAGE_VERSION AC_PACKAGE_NAME"], [Full name and version of this package, with version coming first for libmemcached compatibility])
+AC_DEFINE_UNQUOTED([MCPIPER_PACKAGE_STRING], ["mcpiper mcpiper_version"], [Full name and version of the mcpiper tool])
 
 AC_CONFIG_SRCDIR([CarbonRouterInstance.h])
 AC_CONFIG_HEADERS([config.h:config.hin])

--- a/mcrouter/tools/mcpiper/Config.cpp
+++ b/mcrouter/tools/mcpiper/Config.cpp
@@ -9,6 +9,7 @@
 
 #include <memory>
 
+#include "mcrouter/config.h"
 #include "mcrouter/mcrouter_config.h"
 #include "mcrouter/lib/network/gen/MemcacheRouterInfo.h"
 #include "mcrouter/lib/network/gen/MemcacheServer.h"
@@ -39,7 +40,7 @@ std::unique_ptr<ValueFormatter> createValueFormatter() {
 }
 
 std::string getVersion() {
-  return "mcpiper 1.0";
+  return MCPIPER_PACKAGE_STRING;
 }
 
 bool initCompression() {

--- a/mcrouter/tools/mcpiper/Config.cpp
+++ b/mcrouter/tools/mcpiper/Config.cpp
@@ -9,6 +9,7 @@
 
 #include <memory>
 
+#include "mcrouter/mcrouter_config.h"
 #include "mcrouter/lib/network/gen/MemcacheRouterInfo.h"
 #include "mcrouter/lib/network/gen/MemcacheServer.h"
 #include "mcrouter/tools/mcpiper/MessagePrinter.h"
@@ -30,7 +31,7 @@ constexpr const char* MatchingRequest<Reply>::name() {
 } // namespace detail
 
 std::string getDefaultFifoRoot() {
-  return "/var/mcrouter/fifos";
+  return DEBUG_FIFO_ROOT_DEFAULT;
 }
 
 std::unique_ptr<ValueFormatter> createValueFormatter() {


### PR DESCRIPTION
This PR proposes a change to define the mcpiper version string during `./autogen.sh && ./configure`. It is defined in the generated `config.h` as `MCPIPER_PACKAGE_STRING` and referenced once in `tools/mcpiper/Config.cpp`:

```
/* Full name and version of the mcpiper tool */
#define MCPIPER_PACKAGE_STRING "mcpiper 1.0"
```

Currently the version is defined as literal `1.0` to preserve the existing behavior.

While I'm here I've also refactored the hardcoded constant in this file to the already-`#define`d `DEBUG_FIFO_ROOT_DEFAULT`.

This is motivated by the desire to check (at runtime) if mcpiper is built from the same source as mcrouter. We deploy mcrouter standalone and mcpiper independently, so this change provides the flexibility to override the mcpiper version string (to e.g. a commit hash) at build time that can allow us to identify whether it was built from the same SHA as the mcrouter standalone binary on the same box.