### PR TITLE
Avoid double verification of IP address

### DIFF
--- a/mcrouter/lib/network/AccessPoint.cpp
+++ b/mcrouter/lib/network/AccessPoint.cpp
@@ -9,6 +9,7 @@
 
 #include <folly/Conv.h>
 #include <folly/IPAddress.h>
+#include <folly/IPAddressException.h>
 
 #include "mcrouter/lib/fbi/cpp/util.h"
 
@@ -78,12 +79,12 @@ AccessPoint::AccessPoint(
       compressed_(compressed),
       unixDomainSocket_(unixDomainSocket),
       failureDomain_(failureDomain) {
-  if (folly::IPAddress::validate(host)) {
+  try {
     folly::IPAddress ip(host);
     host_ = ip.toFullyQualified();
     hash_ = folly::hash_value(ip);
     isV6_ = ip.isV6();
-  } else {
+  } catch (const folly::IPAddressFormatException&) {
     // host is not an IP address (e.g. 'localhost')
     host_ = host.str();
     isV6_ = false;


### PR DESCRIPTION
Summary:
Contractor will throw in case address is invalid. This way we can safe one validation.
Exception should be OK in this case.

Reviewed By: stuclar

Differential Revision: D23689585

