### PR TITLE
Avoid setting TCP socket options for Unix domain socket access points

### DIFF
--- a/mcrouter/lib/network/SocketUtil.cpp
+++ b/mcrouter/lib/network/SocketUtil.cpp
@@ -243,6 +243,11 @@ folly::SocketOptionMap createSocketOptions(
     const ConnectionOptions& connectionOptions) {
   folly::SocketOptionMap options;
 
+  if (connectionOptions.accessPoint->isUnixDomainSocket()) {
+    // TCP socket options are not supported by a Unix domain socket transport.
+    return options;
+  }
+
   createTCPKeepAliveOptions(
       options,
       connectionOptions.tcpKeepAliveCount,


### PR DESCRIPTION
Unix domain socket transports specified in config as `unix:/some/path/to/memcached.sock` do not support socket options like TCP keepalive.

When such options are specified on the command line (e.g. `--keepalive-internal`), requests to the socket raise an error like:

```
SERVER_ERROR AsyncSocketException: failed to set socket option (peer=/var/run/memcached/memcached.sock, local=<anonymous unix address>), type = Internal error, errno = 95 (Operation not supported)
```