### PR TITLE
Use pkgconfig to find gtest instead of downloading it

### DIFF
--- a/mcrouter/configure.ac
+++ b/mcrouter/configure.ac
@@ -140,6 +140,22 @@ AC_CHECK_HEADER([folly/Likely.h], [], [AC_MSG_ERROR(
 #AC_CHECK_LIB([wangle], [getenv], [], [AC_MSG_ERROR(
 #             [Please install the wangle library])])
 
+PKG_CHECK_MODULES([GTEST], [gtest], [], [
+  # gtest-devel shipped by CentOS doesn't include a .pc file, so let's fallback
+  # to using normal library and header checks and just set defaults for the
+  # GTEST_* variables.
+  #
+  # The libgtest-dev package in Ubuntu 18.04 is worse, it doesn't even ship
+  # a built library, and only sources... Update the Ubuntu scripts to build
+  # it from source on that platform.
+  AC_CHECK_LIB([gtest], [main], [GTEST_LIBS="-lgtest"], [
+    AC_MSG_ERROR([Please install the gtest library])
+  ])
+  AC_CHECK_HEADER([gtest/gtest.h], [], [
+    AC_MSG_ERROR([Please install the gtest library])
+  ])
+])
+
 # Checks for typedefs, structures, and compiler characteristics.
 AC_HEADER_STDBOOL
 AC_C_CONST

--- a/mcrouter/lib/Makefile.am
+++ b/mcrouter/lib/Makefile.am
@@ -261,6 +261,6 @@ libmcrouter_a_CFLAGS = -I$(top_srcdir)/..
 check_LTLIBRARIES = libtestmain.la
 check_PROGRAMS =
 
-libtestmain_la_CPPFLAGS = -Igtest/include -Igtest
-libtestmain_la_SOURCES = TestMain.cpp gtest/src/gtest-all.cc
-libtestmain_la_LIBADD = -lfolly
+libtestmain_la_CPPFLAGS = $(GTEST_CFLAGS)
+libtestmain_la_SOURCES = TestMain.cpp
+libtestmain_la_LIBADD = -lfolly $(GTEST_LIBS)

--- a/mcrouter/scripts/Makefile_ubuntu-18.04
+++ b/mcrouter/scripts/Makefile_ubuntu-18.04
@@ -1,6 +1,6 @@
 RECIPES_DIR := ./recipes
 
-all: .folly-done .fizz-done .wangle-done .fmt-done .fbthrift-done
+all: .folly-done .fizz-done .wangle-done .fmt-done .fbthrift-done .gtest-done
 	${RECIPES_DIR}/mcrouter.sh $(PKG_DIR) $(INSTALL_DIR) $(INSTALL_AUX_DIR)
 	touch $@
 
@@ -8,7 +8,7 @@ mcrouter:
 	${RECIPES_DIR}/mcrouter.sh $(PKG_DIR) $(INSTALL_DIR) $(INSTALL_AUX_DIR)
 	touch $@
 
-deps: .folly-done .fizz-done .wangle-done .fmt-done .fbthrift-done
+deps: .folly-done .fizz-done .wangle-done .fmt-done .fbthrift-done .gtest-done
 	touch $@
 
 .folly-done: .fmt-done
@@ -29,4 +29,8 @@ deps: .folly-done .fizz-done .wangle-done .fmt-done .fbthrift-done
 
 .fbthrift-done: .folly-done .fizz-done .wangle-done .fmt-done
 	${RECIPES_DIR}/fbthrift.sh $(PKG_DIR) $(INSTALL_DIR) $(INSTALL_AUX_DIR)
+	touch $@
+
+.gtest-done:
+	${RECIPES_DIR}/gtest.sh $(PKG_DIR) $(INSTALL_DIR) $(INSTALL_AUX_DIR)
 	touch $@

--- a/mcrouter/scripts/install_centos_7.2.sh
+++ b/mcrouter/scripts/install_centos_7.2.sh
@@ -28,6 +28,7 @@ sudo yum install -y \
     git \
     gflags-devel \
     glog-devel \
+    gtest-devel \
     jemalloc-devel \
     libtool \
     libevent-devel \

--- a/mcrouter/scripts/recipes/gtest.sh
+++ b/mcrouter/scripts/recipes/gtest.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+source common.sh
+
+if [ ! -d "$PKG_DIR/glog" ]; then
+    git clone https://github.com/google/googletest.git "$PKG_DIR/gtest" \
+        --branch v1.10.x --depth 1
+    cd "$PKG_DIR/gtest" || die "cd fail"
+
+    cmake . \
+        -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
+        -DCMAKE_INSTALL_LIBDIR="lib"
+    make $MAKE_ARGS && make install $MAKE_ARGS
+fi

--- a/mcrouter/scripts/recipes/mcrouter.sh
+++ b/mcrouter/scripts/recipes/mcrouter.sh
@@ -6,14 +6,7 @@
 
 source common.sh
 
-# clone the latest gtest
-[ -d googletest ] || git clone https://github.com/google/googletest.git
-
 cd "$SCRIPT_DIR/../.." || die "cd fail"
-
-# copy gtest source into lib/gtest folder
-mkdir -p ./lib/gtest
-cp -r -f -t ./lib/gtest "$PKG_DIR/googletest/googletest"/*
 
 autoreconf --install
 LD_LIBRARY_PATH="$INSTALL_DIR/lib:$LD_LIBRARY_PATH" \


### PR DESCRIPTION
Summary: This makes the OSS build work on Fedora when using the system provided gtest package.

Differential Revision: D25791770

