### PR TITLE
Test regression: update config file MD5 hash in TestAsyncFiles

### DIFF
--- a/mcrouter/test/test_async_files.py
+++ b/mcrouter/test/test_async_files.py
@@ -16,7 +16,7 @@ class TestAsyncFiles(McrouterTestCase):
     default_route = '/././'
     stat_prefix = 'libmcrouter.mcrouter.0.'
     config = './mcrouter/test/mcrouter_test_basic_1_1_1.json'
-    config_hash = '6bbe796e576bf700f5e3ba8a66d409d5'
+    config_hash = '837ae7d82f2fe7cb785b941dae505811'
     extra_args = ['--stats-logging-interval', '100', '--use-asynclog-version2']
     mock_smc_config = None
 


### PR DESCRIPTION
Apply same config hash value change as in 2e29ad3d30927f612275f23d8b85f824132f29c3 to `test_async_files.py`

```
$ md5sum mcrouter_test_basic_1_1_1.json
837ae7d82f2fe7cb785b941dae505811  mcrouter_test_basic_1_1_1.json
```

This change fixes:

```
======================================================================
FAIL: test_async_files (mcrouter.test.test_async_files.TestAsyncFiles)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/mcrouter/test/test_async_files.py", line 107, in test_async_files
    self.assertEqual(sources_json['mcrouter_config'], self.config_hash)
AssertionError: '837ae7d82f2fe7cb785b941dae505811' != '6bbe796e576bf700f5e3ba8a66d409d5'
- 837ae7d82f2fe7cb785b941dae505811
+ 6bbe796e576bf700f5e3ba8a66d409d5
```