### PR TITLE
Fix missing linker flag for mcrouter and mock_mc_server binaries: -lthriftmetadata

### DIFF
--- a/mcrouter/Makefile.am
+++ b/mcrouter/Makefile.am
@@ -242,6 +242,7 @@ mcrouter_LDADD = \
   -ltransport \
   -lthriftprotocol \
   -lrpcmetadata \
+  -lthriftmetadata \
   -lasync \
   -lconcurrency \
   -lthrift-core \

--- a/mcrouter/lib/network/test/Makefile.am
+++ b/mcrouter/lib/network/test/Makefile.am
@@ -20,6 +20,7 @@ mock_mc_server_LDADD = \
 	-ltransport \
 	-lthriftprotocol \
 	-lrpcmetadata \
+	-lthriftmetadata \
 	-lasync \
 	-lconcurrency \
 	-lthrift-core \


### PR DESCRIPTION
This should solve linker errors from fbthrift:

<details>
<summary>Build error</summary>

```
07:10:30 /bin/bash ../../../libtool  --tag=CXX   --mode=link g++  -DLIBMC_FBTRACE_DISABLE -DDISABLE_COMPRESSION  -Wno-missing-field-initializers -Wno-deprecated -W -Wall -Wextra -Wno-unused-parameter -fno-strict-aliasing -std=c++17 -g -O3 -flto -fPIC   -o mock_mc_server mock_mc_server-MockMc.o mock_mc_server-MockMcServer.o ../../../lib/libmcrouter.a -lthriftcpp2 -ltransport -lthriftprotocol -lrpcmetadata -lasync -lconcurrency -lthrift-core -lfmt -lfizz -lwangle -lfolly -lfizz -lsodium -lfolly -liberty -ldl -ldouble-conversion -lz -lssl -lcrypto -levent -lgflags -lglog -ljemalloc -ldl -L/usr/local/lib -lboost_context -lboost_filesystem       -lboost_program_options -lboost_system -lboost_regex       -lboost_thread -lpthread -pthread -ldl -lunwind       -lbz2 -llz4 -llzma -lsnappy -lzstd
07:10:30 libtool: link: g++ -DLIBMC_FBTRACE_DISABLE -DDISABLE_COMPRESSION -Wno-missing-field-initializers -Wno-deprecated -W -Wall -Wextra -Wno-unused-parameter -fno-strict-aliasing -std=c++17 -g -O3 -flto -fPIC -o mock_mc_server mock_mc_server-MockMc.o mock_mc_server-MockMcServer.o -pthread  ../../../lib/libmcrouter.a -lthriftcpp2 -ltransport -lthriftprotocol -lrpcmetadata -lasync -lconcurrency -lthrift-core -lfmt -lwangle -lfizz -lsodium -lfolly -liberty -ldouble-conversion -lz -lssl -lcrypto /usr/local/lib/libevent.so -lgflags -lglog -ljemalloc -L/usr/local/lib -lboost_context -lboost_filesystem -lboost_program_options -lboost_system -lboost_regex -lboost_thread -lpthread -ldl -lunwind -lbz2 -llz4 -llzma -lsnappy -lzstd -pthread
07:11:05 /usr/bin/ld: /usr/local/lib/libthriftcpp2.a(MultiplexAsyncProcessor.cpp.o): in function `apache::thrift::(anonymous namespace)::MultiplexAsyncProcessor::getServiceMetadata(apache::thrift::metadata::ThriftServiceMetadataResponse&)':
07:11:05 MultiplexAsyncProcessor.cpp:(.text+0x12dd): undefined reference to `apache::thrift::metadata::ThriftEnum::ThriftEnum(apache::thrift::metadata::ThriftEnum const&)'
07:11:05 /usr/bin/ld: MultiplexAsyncProcessor.cpp:(.text+0x1457): undefined reference to `apache::thrift::metadata::ThriftStruct::ThriftStruct(apache::thrift::metadata::ThriftStruct const&)'
07:11:05 /usr/bin/ld: MultiplexAsyncProcessor.cpp:(.text+0x15c5): undefined reference to `apache::thrift::metadata::ThriftException::ThriftException(apache::thrift::metadata::ThriftException const&)'
07:11:05 /usr/bin/ld: MultiplexAsyncProcessor.cpp:(.text+0x173d): undefined reference to `apache::thrift::metadata::ThriftService::ThriftService(apache::thrift::metadata::ThriftService const&)'
07:11:05 /usr/bin/ld: MultiplexAsyncProcessor.cpp:(.text+0x1985): undefined reference to `apache::thrift::metadata::ThriftConstValue::__clear()'
07:11:05 /usr/bin/ld: MultiplexAsyncProcessor.cpp:(.text+0x1a4b): undefined reference to `apache::thrift::metadata::ThriftFunction::~ThriftFunction()'
07:11:05 /usr/bin/ld: MultiplexAsyncProcessor.cpp:(.text+0x1b98): undefined reference to `apache::thrift::metadata::ThriftService::operator=(apache::thrift::metadata::ThriftService const&)'
07:11:05 /usr/bin/ld: MultiplexAsyncProcessor.cpp:(.text+0x1bb1): undefined reference to `apache::thrift::metadata::ThriftModuleContext::operator=(apache::thrift::metadata::ThriftModuleContext const&)'
07:11:05 /usr/bin/ld: /usr/local/lib/libthriftcpp2.a(MultiplexAsyncProcessor.cpp.o): in function `std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, apache::thrift::metadata::ThriftConstValue>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, apache::thrift::metadata::ThriftConstValue> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, apache::thrift::metadata::ThriftConstValue> > >::_M_erase(std::_Rb_tree_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, apache::thrift::metadata::ThriftConstValue> >*)':
07:11:05 MultiplexAsyncProcessor.cpp:(.text._ZNSt8_Rb_treeINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt4pairIKS5_N6apache6thrift8metadata16ThriftConstValueEESt10_Select1stISC_ESt4lessIS5_ESaISC_EE8_M_eraseEPSt13_Rb_tree_nodeISC_E[_ZNSt8_Rb_treeINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt4pairIKS5_N6apache6thrift8metadata16ThriftConstValueEESt10_Select1stISC_ESt4lessIS5_ESaISC_EE8_M_eraseEPSt13_Rb_tree_nodeISC_E]+0x28): undefined reference to `apache::thrift::metadata::ThriftConstValue::__clear()'
07:11:05 /usr/bin/ld: /usr/local/lib/libthriftcpp2.a(MultiplexAsyncProcessor.cpp.o): in function `std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, apache::thrift::metadata::ThriftEnum>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, apache::thrift::metadata::ThriftEnum> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, apache::thrift::metadata::ThriftEnum> > >::_M_erase(std::_Rb_tree_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, apache::thrift::metadata::ThriftEnum> >*)':
07:11:05 MultiplexAsyncProcessor.cpp:(.text._ZNSt8_Rb_treeINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt4pairIKS5_N6apache6thrift8metadata10ThriftEnumEESt10_Select1stISC_ESt4lessIS5_ESaISC_EE8_M_eraseEPSt13_Rb_tree_nodeISC_E[_ZNSt8_Rb_treeINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt4pairIKS5_N6apache6thrift8metadata10ThriftEnumEESt10_Select1stISC_ESt4lessIS5_ESaISC_EE8_M_eraseEPSt13_Rb_tree_nodeISC_E]+0x72): undefined reference to `apache::thrift::metadata::ThriftConstValue::__clear()'
07:11:05 /usr/bin/ld: /usr/local/lib/libthriftcpp2.a(MultiplexAsyncProcessor.cpp.o): in function `std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, apache::thrift::metadata::ThriftStruct>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, apache::thrift::metadata::ThriftStruct> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, apache::thrift::metadata::ThriftStruct> > >::_M_erase(std::_Rb_tree_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, apache::thrift::metadata::ThriftStruct> >*)':
07:11:05 MultiplexAsyncProcessor.cpp:(.text._ZNSt8_Rb_treeINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt4pairIKS5_N6apache6thrift8metadata12ThriftStructEESt10_Select1stISC_ESt4lessIS5_ESaISC_EE8_M_eraseEPSt13_Rb_tree_nodeISC_E[_ZNSt8_Rb_treeINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt4pairIKS5_N6apache6thrift8metadata12ThriftStructEESt10_Select1stISC_ESt4lessIS5_ESaISC_EE8_M_eraseEPSt13_Rb_tree_nodeISC_E]+0x72): undefined reference to `apache::thrift::metadata::ThriftConstValue::__clear()'
07:11:05 /usr/bin/ld: MultiplexAsyncProcessor.cpp:(.text._ZNSt8_Rb_treeINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt4pairIKS5_N6apache6thrift8metadata12ThriftStructEESt10_Select1stISC_ESt4lessIS5_ESaISC_EE8_M_eraseEPSt13_Rb_tree_nodeISC_E[_ZNSt8_Rb_treeINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt4pairIKS5_N6apache6thrift8metadata12ThriftStructEESt10_Select1stISC_ESt4lessIS5_ESaISC_EE8_M_eraseEPSt13_Rb_tree_nodeISC_E]+0xfb): undefined reference to `apache::thrift::metadata::ThriftField::~ThriftField()'
07:11:05 /usr/bin/ld: /usr/local/lib/libthriftcpp2.a(MultiplexAsyncProcessor.cpp.o): in function `std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, apache::thrift::metadata::ThriftException>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, apache::thrift::metadata::ThriftException> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, apache::thrift::metadata::ThriftException> > >::_M_erase(std::_Rb_tree_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, apache::thrift::metadata::ThriftException> >*)':
07:11:05 MultiplexAsyncProcessor.cpp:(.text._ZNSt8_Rb_treeINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt4pairIKS5_N6apache6thrift8metadata15ThriftExceptionEESt10_Select1stISC_ESt4lessIS5_ESaISC_EE8_M_eraseEPSt13_Rb_tree_nodeISC_E[_ZNSt8_Rb_treeINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt4pairIKS5_N6apache6thrift8metadata15ThriftExceptionEESt10_Select1stISC_ESt4lessIS5_ESaISC_EE8_M_eraseEPSt13_Rb_tree_nodeISC_E]+0x72): undefined reference to `apache::thrift::metadata::ThriftConstValue::__clear()'
07:11:05 /usr/bin/ld: MultiplexAsyncProcessor.cpp:(.text._ZNSt8_Rb_treeINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt4pairIKS5_N6apache6thrift8metadata15ThriftExceptionEESt10_Select1stISC_ESt4lessIS5_ESaISC_EE8_M_eraseEPSt13_Rb_tree_nodeISC_E[_ZNSt8_Rb_treeINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt4pairIKS5_N6apache6thrift8metadata15ThriftExceptionEESt10_Select1stISC_ESt4lessIS5_ESaISC_EE8_M_eraseEPSt13_Rb_tree_nodeISC_E]+0xfb): undefined reference to `apache::thrift::metadata::ThriftField::~ThriftField()'
07:11:05 /usr/bin/ld: /usr/local/lib/libthriftcpp2.a(MultiplexAsyncProcessor.cpp.o): in function `std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, apache::thrift::metadata::ThriftService>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, apache::thrift::metadata::ThriftService> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, apache::thrift::metadata::ThriftService> > >::_M_erase(std::_Rb_tree_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, apache::thrift::metadata::ThriftService> >*)':
07:11:05 MultiplexAsyncProcessor.cpp:(.text._ZNSt8_Rb_treeINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt4pairIKS5_N6apache6thrift8metadata13ThriftServiceEESt10_Select1stISC_ESt4lessIS5_ESaISC_EE8_M_eraseEPSt13_Rb_tree_nodeISC_E[_ZNSt8_Rb_treeINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt4pairIKS5_N6apache6thrift8metadata13ThriftServiceEESt10_Select1stISC_ESt4lessIS5_ESaISC_EE8_M_eraseEPSt13_Rb_tree_nodeISC_E]+0x72): undefined reference to `apache::thrift::metadata::ThriftConstValue::__clear()'
07:11:05 /usr/bin/ld: MultiplexAsyncProcessor.cpp:(.text._ZNSt8_Rb_treeINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt4pairIKS5_N6apache6thrift8metadata13ThriftServiceEESt10_Select1stISC_ESt4lessIS5_ESaISC_EE8_M_eraseEPSt13_Rb_tree_nodeISC_E[_ZNSt8_Rb_treeINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt4pairIKS5_N6apache6thrift8metadata13ThriftServiceEESt10_Select1stISC_ESt4lessIS5_ESaISC_EE8_M_eraseEPSt13_Rb_tree_nodeISC_E]+0x113): undefined reference to `apache::thrift::metadata::ThriftFunction::~ThriftFunction()'
07:11:05 /usr/bin/ld: /usr/local/lib/libthriftcpp2.a(MultiplexAsyncProcessor.cpp.o): in function `apache::thrift::metadata::ThriftServiceMetadataResponse::~ThriftServiceMetadataResponse()':
07:11:05 MultiplexAsyncProcessor.cpp:(.text._ZN6apache6thrift8metadata29ThriftServiceMetadataResponseD2Ev[_ZN6apache6thrift8metadata29ThriftServiceMetadataResponseD5Ev]+0x115): undefined reference to `apache::thrift::metadata::ThriftConstValue::__clear()'
07:11:05 /usr/bin/ld: MultiplexAsyncProcessor.cpp:(.text._ZN6apache6thrift8metadata29ThriftServiceMetadataResponseD2Ev[_ZN6apache6thrift8metadata29ThriftServiceMetadataResponseD5Ev]+0x1cb): undefined reference to `apache::thrift::metadata::ThriftFunction::~ThriftFunction()'
07:11:05 /usr/bin/ld: /usr/local/lib/libthriftcpp2.a(MultiplexAsyncProcessor.cpp.o): in function `void std::vector<apache::thrift::metadata::ThriftServiceContextRef, std::allocator<apache::thrift::metadata::ThriftServiceContextRef> >::_M_range_insert<__gnu_cxx::__normal_iterator<apache::thrift::metadata::ThriftServiceContextRef*, std::vector<apache::thrift::metadata::ThriftServiceContextRef, std::allocator<apache::thrift::metadata::ThriftServiceContextRef> > > >(__gnu_cxx::__normal_iterator<apache::thrift::metadata::ThriftServiceContextRef*, std::vector<apache::thrift::metadata::ThriftServiceContextRef, std::allocator<apache::thrift::metadata::ThriftServiceContextRef> > >, __gnu_cxx::__normal_iterator<apache::thrift::metadata::ThriftServiceContextRef*, std::vector<apache::thrift::metadata::ThriftServiceContextRef, std::allocator<apache::thrift::metadata::ThriftServiceContextRef> > >, __gnu_cxx::__normal_iterator<apache::thrift::metadata::ThriftServiceContextRef*, std::vector<apache::thrift::metadata::ThriftServiceContextRef, std::allocator<apache::thrift::metadata::ThriftServiceContextRef> > >, std::forward_iterator_tag)':
07:11:05 MultiplexAsyncProcessor.cpp:(.text._ZNSt6vectorIN6apache6thrift8metadata23ThriftServiceContextRefESaIS3_EE15_M_range_insertIN9__gnu_cxx17__normal_iteratorIPS3_S5_EEEEvSA_T_SB_St20forward_iterator_tag[_ZNSt6vectorIN6apache6thrift8metadata23ThriftServiceContextRefESaIS3_EE15_M_range_insertIN9__gnu_cxx17__normal_iteratorIPS3_S5_EEEEvSA_T_SB_St20forward_iterator_tag]+0xb9): undefined reference to `apache::thrift::metadata::ThriftServiceContextRef::ThriftServiceContextRef(apache::thrift::metadata::ThriftServiceContextRef&&)'
07:11:05 /usr/bin/ld: MultiplexAsyncProcessor.cpp:(.text._ZNSt6vectorIN6apache6thrift8metadata23ThriftServiceContextRefESaIS3_EE15_M_range_insertIN9__gnu_cxx17__normal_iteratorIPS3_S5_EEEEvSA_T_SB_St20forward_iterator_tag[_ZNSt6vectorIN6apache6thrift8metadata23ThriftServiceContextRefESaIS3_EE15_M_range_insertIN9__gnu_cxx17__normal_iteratorIPS3_S5_EEEEvSA_T_SB_St20forward_iterator_tag]+0x10f): undefined reference to `apache::thrift::metadata::ThriftServiceContextRef::operator=(apache::thrift::metadata::ThriftServiceContextRef&&)'
07:11:05 /usr/bin/ld: MultiplexAsyncProcessor.cpp:(.text._ZNSt6vectorIN6apache6thrift8metadata23ThriftServiceContextRefESaIS3_EE15_M_range_insertIN9__gnu_cxx17__normal_iteratorIPS3_S5_EEEEvSA_T_SB_St20forward_iterator_tag[_ZNSt6vectorIN6apache6thrift8metadata23ThriftServiceContextRefESaIS3_EE15_M_range_insertIN9__gnu_cxx17__normal_iteratorIPS3_S5_EEEEvSA_T_SB_St20forward_iterator_tag]+0x137): undefined reference to `apache::thrift::metadata::ThriftServiceContextRef::operator=(apache::thrift::metadata::ThriftServiceContextRef const&)'
07:11:05 /usr/bin/ld: MultiplexAsyncProcessor.cpp:(.text._ZNSt6vectorIN6apache6thrift8metadata23ThriftServiceContextRefESaIS3_EE15_M_range_insertIN9__gnu_cxx17__normal_iteratorIPS3_S5_EEEEvSA_T_SB_St20forward_iterator_tag[_ZNSt6vectorIN6apache6thrift8metadata23ThriftServiceContextRefESaIS3_EE15_M_range_insertIN9__gnu_cxx17__normal_iteratorIPS3_S5_EEEEvSA_T_SB_St20forward_iterator_tag]+0x1c7): undefined reference to `apache::thrift::metadata::ThriftServiceContextRef::ThriftServiceContextRef(apache::thrift::metadata::ThriftServiceContextRef&&)'
07:11:05 /usr/bin/ld: MultiplexAsyncProcessor.cpp:(.text._ZNSt6vectorIN6apache6thrift8metadata23ThriftServiceContextRefESaIS3_EE15_M_range_insertIN9__gnu_cxx17__normal_iteratorIPS3_S5_EEEEvSA_T_SB_St20forward_iterator_tag[_ZNSt6vectorIN6apache6thrift8metadata23ThriftServiceContextRefESaIS3_EE15_M_range_insertIN9__gnu_cxx17__normal_iteratorIPS3_S5_EEEEvSA_T_SB_St20forward_iterator_tag]+0x217): undefined reference to `apache::thrift::metadata::ThriftServiceContextRef::ThriftServiceContextRef(apache::thrift::metadata::ThriftServiceContextRef const&)'
07:11:05 /usr/bin/ld: MultiplexAsyncProcessor.cpp:(.text._ZNSt6vectorIN6apache6thrift8metadata23ThriftServiceContextRefESaIS3_EE15_M_range_insertIN9__gnu_cxx17__normal_iteratorIPS3_S5_EEEEvSA_T_SB_St20forward_iterator_tag[_ZNSt6vectorIN6apache6thrift8metadata23ThriftServiceContextRefESaIS3_EE15_M_range_insertIN9__gnu_cxx17__normal_iteratorIPS3_S5_EEEEvSA_T_SB_St20forward_iterator_tag]+0x24f): undefined reference to `apache::thrift::metadata::ThriftServiceContextRef::ThriftServiceContextRef(apache::thrift::metadata::ThriftServiceContextRef&&)'
07:11:05 /usr/bin/ld: MultiplexAsyncProcessor.cpp:(.text._ZNSt6vectorIN6apache6thrift8metadata23ThriftServiceContextRefESaIS3_EE15_M_range_insertIN9__gnu_cxx17__normal_iteratorIPS3_S5_EEEEvSA_T_SB_St20forward_iterator_tag[_ZNSt6vectorIN6apache6thrift8metadata23ThriftServiceContextRefESaIS3_EE15_M_range_insertIN9__gnu_cxx17__normal_iteratorIPS3_S5_EEEEvSA_T_SB_St20forward_iterator_tag]+0x337): undefined reference to `apache::thrift::metadata::ThriftServiceContextRef::ThriftServiceContextRef(apache::thrift::metadata::ThriftServiceContextRef const&)'
07:11:05 /usr/bin/ld: MultiplexAsyncProcessor.cpp:(.text._ZNSt6vectorIN6apache6thrift8metadata23ThriftServiceContextRefESaIS3_EE15_M_range_insertIN9__gnu_cxx17__normal_iteratorIPS3_S5_EEEEvSA_T_SB_St20forward_iterator_tag[_ZNSt6vectorIN6apache6thrift8metadata23ThriftServiceContextRefESaIS3_EE15_M_range_insertIN9__gnu_cxx17__normal_iteratorIPS3_S5_EEEEvSA_T_SB_St20forward_iterator_tag]+0x387): undefined reference to `apache::thrift::metadata::ThriftServiceContextRef::ThriftServiceContextRef(apache::thrift::metadata::ThriftServiceContextRef&&)'
07:11:05 /usr/bin/ld: MultiplexAsyncProcessor.cpp:(.text._ZNSt6vectorIN6apache6thrift8metadata23ThriftServiceContextRefESaIS3_EE15_M_range_insertIN9__gnu_cxx17__normal_iteratorIPS3_S5_EEEEvSA_T_SB_St20forward_iterator_tag[_ZNSt6vectorIN6apache6thrift8metadata23ThriftServiceContextRefESaIS3_EE15_M_range_insertIN9__gnu_cxx17__normal_iteratorIPS3_S5_EEEEvSA_T_SB_St20forward_iterator_tag]+0x3bf): undefined reference to `apache::thrift::metadata::ThriftServiceContextRef::operator=(apache::thrift::metadata::ThriftServiceContextRef const&)'
```
</details>

Which is ultimately caused by a change to [`MultiplexAsyncProcessor.cpp`](https://github.com/facebook/fbthrift/commit/2c36598d745ba962f2c7bfe851ae9864e6785456#diff-fa03e279f32e93737a5658d2dc39d9a11b49cab2042dcc7d216a82f70c00cfef), included in `thriftcpp2`, which depends on the `thriftmetadata` library.