### PR TITLE
link thriftmetadata since thriftcpp2 depends on it

### DIFF
--- a/mcrouter/Makefile.am
+++ b/mcrouter/Makefile.am
@@ -238,6 +238,7 @@ libmcroutercore_a_CPPFLAGS = -I..
 mcrouter_LDADD = \
   libmcroutercore.a \
   lib/libmcrouter.a \
+  -lthriftmetadata \
   -lthriftcpp2 \
   -ltransport \
   -lthriftprotocol \
@@ -245,7 +246,7 @@ mcrouter_LDADD = \
   -lasync \
   -lconcurrency \
   -lthrift-core \
-	-lfmt \
+  -lfmt \
   -lwangle \
   -lfolly
 

--- a/mcrouter/Makefile.am
+++ b/mcrouter/Makefile.am
@@ -238,8 +238,8 @@ libmcroutercore_a_CPPFLAGS = -I..
 mcrouter_LDADD = \
   libmcroutercore.a \
   lib/libmcrouter.a \
-  -lthriftmetadata \
   -lthriftcpp2 \
+  -lthriftmetadata \
   -ltransport \
   -lthriftprotocol \
   -lrpcmetadata \


### PR DESCRIPTION
Just as the title says. I was trying to build from source using the included script targetting Ubuntu 20.04 and I was greeted with link errors such as:

```
/usr/bin/ld: /root/install/install/lib/libthriftcpp2.a(MultiplexAsyncProcessor.cpp.o): in function `apache::thrift::(anonymous namespace)::MultiplexAsyncProcessor::getServiceMetadata(apache::thrift::metadata::ThriftServiceMetadataResponse&)':
MultiplexAsyncProcessor.cpp:(.text+0x2e63): undefined reference to `apache::thrift::metadata::ThriftService::operator=(apache::thrift::metadata::ThriftService const&)'
```

So I took a quick look at the link line:

/bin/bash ../../../libtool  --tag=CXX   --mode=link g++  -DLIBMC_FBTRACE_DISABLE -DDISABLE_COMPRESSION  -Wno-missing-field-initializers -Wno-deprecated -W -Wall -Wextra -Wno-unused-parameter -fno-strict-aliasing -std=c++17 -g -O2  -L/root/install/install/lib -ljemalloc  -o mock_mc_server mock_mc_server-MockMc.o mock_mc_server-MockMcServer.o ../../../lib/libmcrouter.a **-lthriftcpp2 -ltransport -lthriftprotocol -lrpcmetadata -lasync -lconcurrency -lthrift-core** -lfmt -lfizz -lwangle -lfolly -lfizz -lsodium -lfolly -ldl -ldouble-conversion -lz -lssl -lcrypto -levent -lgflags -lglog  -L/usr/lib/x86_64-linux-gnu -lboost_context -lboost_filesystem       -lboost_program_options -lboost_system -lboost_regex       -lboost_thread -lpthread -pthread -ldl -lunwind       -lbz2 -llz4 -llzma -lsnappy -lzstd

Then I confirmed what the linker was saying with `nm`:

```
root@ac5fb51f7456:~/mcrouter/mcrouter/lib/network/test# for lib in /root/install/install/lib/*.a; do echo ${lib}; nm -C ${lib} | grep -F "ThriftService::operator="; done
/root/install/install/lib/libasync.a
/root/install/install/lib/libcompiler_ast.a
/root/install/install/lib/libcompiler_base.a
/root/install/install/lib/libcompiler_lib.a
/root/install/install/lib/libconcurrency.a
/root/install/install/lib/libfizz.a
/root/install/install/lib/libfizz_test_support.a
/root/install/install/lib/libfmt.a
/root/install/install/lib/libfolly.a
/root/install/install/lib/libfolly_test_util.a
/root/install/install/lib/libfollybenchmark.a
/root/install/install/lib/libgmock.a
/root/install/install/lib/libgmock_main.a
/root/install/install/lib/libgtest.a
/root/install/install/lib/libgtest_main.a
/root/install/install/lib/libmustache_lib.a
/root/install/install/lib/librpcmetadata.a
/root/install/install/lib/libthrift-core.a
/root/install/install/lib/libthriftcpp2.a
                 U apache::thrift::metadata::ThriftService::operator=(apache::thrift::metadata::ThriftService const&)
/root/install/install/lib/libthriftfrozen2.a
/root/install/install/lib/libthriftmetadata.a
000000000000eefa T apache::thrift::metadata::ThriftService::operator=(apache::thrift::metadata::ThriftService&&)
000000000000edbe T apache::thrift::metadata::ThriftService::operator=(apache::thrift::metadata::ThriftService const&)
000000000000f180 T apache::thrift::metadata::ThriftService::operator==(apache::thrift::metadata::ThriftService const&) const
                 U apache::thrift::metadata::ThriftService::operator=(apache::thrift::metadata::ThriftService const&)
```
So indeed `thriftcpp2` doesn't have a definition for the assignment operator but `thriftmetadata` does. So I manually tried adding it to the link line and it linked no problem. This pr simply adds the flag to autotools `Makefile.am` so that the generated makefile knows to link that.