### PR TITLE
Expose per-server request counters by request class in `stats servers`

### DIFF
--- a/mcrouter/ProxyDestination-inl.h
+++ b/mcrouter/ProxyDestination-inl.h
@@ -10,6 +10,7 @@
 
 #include <folly/io/async/AsyncSSLSocket.h>
 
+#include "mcrouter/McrouterFiberContext.h"
 #include "mcrouter/OptionsUtil.h"
 #include "mcrouter/ProxyBase.h"
 #include "mcrouter/ProxyDestinationMap.h"
@@ -160,6 +161,12 @@ void ProxyDestination<Transport>::onReply(
   }
   ++(*stats().results)[static_cast<size_t>(result)];
   destreqCtx.endTime = nowUs();
+
+  if (destreqCtx.requestClass.is(RequestClass::kFailover)) {
+    ++stats().failoverRequests;
+  } else if (destreqCtx.requestClass.is(RequestClass::kShadow)) {
+    ++stats().shadowRequests;
+  }
 
   int64_t latency = destreqCtx.endTime - destreqCtx.startTime;
   stats().avgLatency.insertSample(latency);

--- a/mcrouter/ProxyDestination.h
+++ b/mcrouter/ProxyDestination.h
@@ -14,6 +14,7 @@
 #include <folly/Range.h>
 #include <folly/SpinLock.h>
 
+#include "mcrouter/McrouterFiberContext.h"
 #include "mcrouter/ProxyDestinationBase.h"
 #include "mcrouter/TkoLog.h"
 #include "mcrouter/config.h"
@@ -34,10 +35,15 @@ class ProxyDestinationMap;
 class TkoTracker;
 
 struct DestinationRequestCtx {
+  RequestClass requestClass;
   int64_t startTime{0};
   int64_t endTime{0};
 
-  explicit DestinationRequestCtx(int64_t now) : startTime(now) {}
+  explicit DestinationRequestCtx(
+      RequestClass requestClass,
+      int64_t now)
+      : requestClass(requestClass),
+        startTime(now) {}
 };
 
 template <class Transport>

--- a/mcrouter/ProxyDestinationBase.h
+++ b/mcrouter/ProxyDestinationBase.h
@@ -67,6 +67,8 @@ class ProxyDestinationBase {
 
     // last time this connection was closed due to inactivity
     uint64_t inactiveConnectionClosedTimestampUs{0};
+    uint64_t failoverRequests{0};
+    uint64_t shadowRequests{0};
   };
 
   ProxyDestinationBase(

--- a/mcrouter/routes/DestinationRoute.h
+++ b/mcrouter/routes/DestinationRoute.h
@@ -238,7 +238,9 @@ class DestinationRoute {
   ReplyT<Request> doRoute(
       const Request& req,
       ProxyRequestContextWithInfo<RouterInfo>& ctx) const {
-    DestinationRequestCtx dctx(nowUs());
+    DestinationRequestCtx dctx(
+        fiber_local<RouterInfo>::getRequestClass(),
+        nowUs());
     folly::Optional<Request> newReq;
     folly::StringPiece strippedRoutingPrefix;
     if (!keepRoutingPrefix_ && !req.key_ref()->routingPrefix().empty()) {

--- a/mcrouter/stats.cpp
+++ b/mcrouter/stats.cpp
@@ -73,6 +73,8 @@ struct ServerStat {
   size_t cntLatencies{0};
   size_t pendingRequestsCount{0};
   size_t inflightRequestsCount{0};
+  size_t failoverRequestsCount{0};
+  size_t shadowRequestsCount{0};
   double sumRetransPerKByte{0.0};
   size_t cntRetransPerKByte{0};
   double maxRetransPerKByte{0.0};
@@ -83,6 +85,8 @@ struct ServerStat {
     auto res = folly::format("avg_latency_us:{:.3f}", avgLatency).str();
     folly::format(" pending_reqs:{}", pendingRequestsCount).appendTo(res);
     folly::format(" inflight_reqs:{}", inflightRequestsCount).appendTo(res);
+    folly::format(" failover_reqs:{}", failoverRequestsCount).appendTo(res);
+    folly::format(" shadow_reqs:{}", shadowRequestsCount).appendTo(res);
     if (isHardTko) {
       res.append(" hard_tko; ");
     } else if (isSoftTko) {
@@ -744,6 +748,8 @@ McStatsReply stats_reply(ProxyBase* proxy, folly::StringPiece group_str) {
             auto reqStats = pdstn.getRequestStats();
             stat.pendingRequestsCount += reqStats.numPending;
             stat.inflightRequestsCount += reqStats.numInflight;
+            stat.failoverRequestsCount += pdstn.stats().failoverRequests;
+            stat.shadowRequestsCount += pdstn.stats().shadowRequests;
           });
     }
     for (const auto& it : serverStats) {


### PR DESCRIPTION
An observability problem that comes up quite often is determining the rate of requests (or a ratio of total requests) for a particular server that is due to failover traffic. For example, in an active-active HA cluster, this would help estimate the "efficiency" of a failover policy in an outage scenario where one replica is partially or entirely unavailable. Under normal operating conditions, this information can also be combined with TKO stats to track failover behavior during transient failures along both per-client and per-server dimensions.

This change proposes the addition of two new keys to per-server stats in `stats servers`, `failover_reqs` and `shadow_reqs`, which report the cumulative count of outbound requests for a proxy destination that occurred due to failover or shadow policies, respectively, as determined by its request class.

The implementation proposes adding an additional field to `DestinationRequestCtx`, whose value is used to increment stats in `ProxyDestination-inl.h` which are then finally exposed to `stats servers` in `stats.cpp`.