### PR TITLE
Fix error setting transport local address in debug fifos when using Unix socket listeners

### DIFF
--- a/mcrouter/lib/debug/ConnectionFifo.cpp
+++ b/mcrouter/lib/debug/ConnectionFifo.cpp
@@ -126,6 +126,7 @@ MessageHeader buildMsgHeader(
       address.getAddressStr(
           header.peerAddressModifiable(), MessageHeader::kAddressMaxSize);
       header.setPeerPort(address.getPort());
+      header.setLocalPort(address.getPort());
     } else if (address.getFamily() == AF_UNIX) {
       // For unix sockets, just localAddress has the path.
       transport->getLocalAddress(&address);
@@ -138,7 +139,6 @@ MessageHeader buildMsgHeader(
     }
 
     transport->getLocalAddress(&address);
-    header.setLocalPort(address.getPort());
   } catch (const std::exception& e) {
     VLOG(2) << "Error getting host/port to write to debug fifo: " << e.what();
   }


### PR DESCRIPTION
This change fixes the following error:

```
I0223 00:47:32.829787     8 ConnectionFifo.cpp:143] Error getting host/port to write to debug fifo: SocketAddress::getPort() called on non-IP address
```

Which appears when mcrouter is configured to listen on a Unix domain socket and a new client connection arrives on the socket. Port information is only available for `AF_INET` and `AF_INET6` sockets.