### PR TITLE
Fix build for mcrouter, mock_mc_server, mcpiper targets following fbthrift changes

### DIFF
--- a/mcrouter/Makefile.am
+++ b/mcrouter/Makefile.am
@@ -244,6 +244,9 @@ mcrouter_LDADD = \
   lib/libmcrouter.a \
   -lthriftcpp2 \
   -ltransport \
+  -lthrifttype \
+  -lthrifttyperep \
+  -lthriftanyrep \
   -lthriftprotocol \
   -lrpcmetadata \
   -lthriftmetadata \

--- a/mcrouter/lib/network/test/Makefile.am
+++ b/mcrouter/lib/network/test/Makefile.am
@@ -18,6 +18,9 @@ mock_mc_server_LDADD = \
 	$(top_builddir)/lib/libmcrouter.a \
 	-lthriftcpp2 \
 	-ltransport \
+	-lthrifttype \
+	-lthrifttyperep \
+	-lthriftanyrep \
 	-lthriftprotocol \
 	-lrpcmetadata \
 	-lthriftmetadata \

--- a/mcrouter/tools/mcpiper/Makefile.am
+++ b/mcrouter/tools/mcpiper/Makefile.am
@@ -38,6 +38,9 @@ mcpiper_LDADD = \
 	$(top_srcdir)/lib/libmcrouter.a \
 	-lthriftcpp2 \
 	-ltransport \
+	-lthrifttype \
+	-lthrifttyperep \
+	-lthriftanyrep \
 	-lthriftprotocol \
 	-lrpcmetadata \
 	-lasync \


### PR DESCRIPTION
Build error symptom after upgrading to fbthrift `v2022.06.06.00` or later:

```
07:12:27  /bin/bash ../../../libtool  --tag=CXX   --mode=link g++  -DLIBMC_FBTRACE_DISABLE -DDISABLE_COMPRESSION  -Wno-missing-field-initializers -Wno-deprecated -W -Wall -Wextra -Wno-unused-parameter -fno-strict-aliasing -std=c++17 -g -O3 -flto -fPIC   -o mock_mc_server mock_mc_server-MockMc.o mock_mc_server-MockMcServer.o ../../../lib/libmcrouter.a -lthriftcpp2 -ltransport -lthriftprotocol -lrpcmetadata -lthriftmetadata -lasync -lconcurrency -lthrift-core -lfmt -lfizz -lwangle -lfolly -lfizz -lsodium -lfolly -liberty -ldl -ldouble-conversion -lz -lssl -lcrypto -levent -lgflags -lglog -ljemalloc -ldl -L/usr/local/lib -lboost_context -lboost_filesystem       -lboost_program_options -lboost_system -lboost_regex       -lboost_thread -lpthread -pthread -ldl -lunwind       -lbz2 -llz4 -llzma -lsnappy -lzstd
07:12:27  libtool: link: g++ -DLIBMC_FBTRACE_DISABLE -DDISABLE_COMPRESSION -Wno-missing-field-initializers -Wno-deprecated -W -Wall -Wextra -Wno-unused-parameter -fno-strict-aliasing -std=c++17 -g -O3 -flto -fPIC -o mock_mc_server mock_mc_server-MockMc.o mock_mc_server-MockMcServer.o -pthread  ../../../lib/libmcrouter.a -lthriftcpp2 -ltransport -lthriftprotocol -lrpcmetadata -lthriftmetadata -lasync -lconcurrency -lthrift-core -lfmt -lwangle -lfizz -lsodium -lfolly -liberty -ldouble-conversion -lz -lssl -lcrypto /usr/local/lib/libevent.so -lgflags -lglog -ljemalloc -L/usr/local/lib -lboost_context -lboost_filesystem -lboost_program_options -lboost_system -lboost_regex -lboost_thread -lpthread -ldl /usr/local/lib/libunwind.so -lbz2 -llz4 -llzma -lsnappy -lzstd -pthread
07:13:06  /usr/bin/ld: /usr/local/lib/libthriftcpp2.a(RocketThriftRequests.cpp.o): in function `folly::exception_wrapper apache::thrift::rocket::(anonymous namespace)::processFirstResponseHelper<apache::thrift::Serializer<apache::thrift::BinaryProtocolReader, apache::thrift::BinaryProtocolWriter> >(apache::thrift::ResponseRpcMetadata&, std::unique_ptr<folly::IOBuf, std::default_delete<folly::IOBuf> >&, int)':
07:13:06  RocketThriftRequests.cpp:(.text+0x4d2c): undefined reference to `apache::thrift::type::TypeStruct::operator=(apache::thrift::type::TypeStruct const&)'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text+0x4d44): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text+0x4d80): undefined reference to `apache::thrift::type::ProtocolUnion::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text+0x4da8): undefined reference to `apache::thrift::type::ProtocolUnion::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text+0x4dd8): undefined reference to `apache::thrift::type::ProtocolUnion::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text+0x4df8): undefined reference to `apache::thrift::type::ProtocolUnion::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text+0x4ea8): undefined reference to `unsigned int apache::thrift::type::SemiAnyStruct::write<apache::thrift::BinaryProtocolWriter>(apache::thrift::BinaryProtocolWriter*) const'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text+0x4f00): undefined reference to `apache::thrift::type::ProtocolUnion::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text+0x4f28): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text+0x4f50): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text+0x561c): undefined reference to `apache::thrift::type::ProtocolUnion::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text+0x5638): undefined reference to `apache::thrift::type::ProtocolUnion::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text+0x5b30): undefined reference to `apache::thrift::type::ProtocolUnion::__fbthrift_clear()'
07:13:06  /usr/bin/ld: /usr/local/lib/libthriftcpp2.a(RocketThriftRequests.cpp.o): in function `folly::exception_wrapper apache::thrift::rocket::(anonymous namespace)::processFirstResponseHelper<apache::thrift::Serializer<apache::thrift::CompactProtocolReader, apache::thrift::CompactProtocolWriter> >(apache::thrift::ResponseRpcMetadata&, std::unique_ptr<folly::IOBuf, std::default_delete<folly::IOBuf> >&, int)':
07:13:06  RocketThriftRequests.cpp:(.text+0x7268): undefined reference to `apache::thrift::type::TypeStruct::operator=(apache::thrift::type::TypeStruct const&)'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text+0x7280): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text+0x7374): undefined reference to `unsigned int apache::thrift::type::SemiAnyStruct::write<apache::thrift::CompactProtocolWriter>(apache::thrift::CompactProtocolWriter*) const'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text+0x73dc): undefined reference to `apache::thrift::type::ProtocolUnion::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text+0x7400): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text+0x7428): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: /usr/local/lib/libthriftcpp2.a(RocketThriftRequests.cpp.o): in function `apache::thrift::type::Protocol::~Protocol()':
07:13:06  RocketThriftRequests.cpp:(.text._ZN6apache6thrift4type8ProtocolD2Ev[_ZN6apache6thrift4type8ProtocolD5Ev]+0x8): undefined reference to `apache::thrift::type::ProtocolUnion::__fbthrift_clear()'
07:13:06  /usr/bin/ld: /usr/local/lib/libthriftcpp2.a(RocketThriftRequests.cpp.o): in function `std::vector<apache::thrift::type::TypeStruct, std::allocator<apache::thrift::type::TypeStruct> >::~vector()':
07:13:06  RocketThriftRequests.cpp:(.text._ZNSt6vectorIN6apache6thrift4type10TypeStructESaIS3_EED2Ev[_ZNSt6vectorIN6apache6thrift4type10TypeStructESaIS3_EED5Ev]+0x78): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text._ZNSt6vectorIN6apache6thrift4type10TypeStructESaIS3_EED2Ev[_ZNSt6vectorIN6apache6thrift4type10TypeStructESaIS3_EED5Ev]+0xa4): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text._ZNSt6vectorIN6apache6thrift4type10TypeStructESaIS3_EED2Ev[_ZNSt6vectorIN6apache6thrift4type10TypeStructESaIS3_EED5Ev]+0xd0): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text._ZNSt6vectorIN6apache6thrift4type10TypeStructESaIS3_EED2Ev[_ZNSt6vectorIN6apache6thrift4type10TypeStructESaIS3_EED5Ev]+0xfc): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text._ZNSt6vectorIN6apache6thrift4type10TypeStructESaIS3_EED2Ev[_ZNSt6vectorIN6apache6thrift4type10TypeStructESaIS3_EED5Ev]+0x128): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: /usr/local/lib/libthriftcpp2.a(RocketThriftRequests.cpp.o):RocketThriftRequests.cpp:(.text._ZNSt6vectorIN6apache6thrift4type10TypeStructESaIS3_EED2Ev[_ZNSt6vectorIN6apache6thrift4type10TypeStructESaIS3_EED5Ev]+0x174): more undefined references to `apache::thrift::type::TypeName::__fbthrift_clear()' follow
07:13:06  /usr/bin/ld: /usr/local/lib/libthriftcpp2.a(RocketThriftRequests.cpp.o): in function `apache::thrift::type::Type::Type(apache::thrift::type::exception_c, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)':
07:13:06  RocketThriftRequests.cpp:(.text._ZN6apache6thrift4type4TypeC2ENS1_11exception_cENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN6apache6thrift4type4TypeC5ENS1_11exception_cENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x84): undefined reference to `apache::thrift::type::Type::checkName(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text._ZN6apache6thrift4type4TypeC2ENS1_11exception_cENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN6apache6thrift4type4TypeC5ENS1_11exception_cENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x98): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text._ZN6apache6thrift4type4TypeC2ENS1_11exception_cENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN6apache6thrift4type4TypeC5ENS1_11exception_cENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0xac): undefined reference to `apache::thrift::type::TypeUri::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text._ZN6apache6thrift4type4TypeC2ENS1_11exception_cENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN6apache6thrift4type4TypeC5ENS1_11exception_cENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0xf0): undefined reference to `apache::thrift::type::TypeStruct::TypeStruct(apache::thrift::type::TypeStruct&&)'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text._ZN6apache6thrift4type4TypeC2ENS1_11exception_cENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN6apache6thrift4type4TypeC5ENS1_11exception_cENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x154): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text._ZN6apache6thrift4type4TypeC2ENS1_11exception_cENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN6apache6thrift4type4TypeC5ENS1_11exception_cENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x184): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text._ZN6apache6thrift4type4TypeC2ENS1_11exception_cENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN6apache6thrift4type4TypeC5ENS1_11exception_cENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x1b0): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text._ZN6apache6thrift4type4TypeC2ENS1_11exception_cENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN6apache6thrift4type4TypeC5ENS1_11exception_cENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x1dc): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text._ZN6apache6thrift4type4TypeC2ENS1_11exception_cENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN6apache6thrift4type4TypeC5ENS1_11exception_cENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x208): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: /usr/local/lib/libthriftcpp2.a(RocketThriftRequests.cpp.o):RocketThriftRequests.cpp:(.text._ZN6apache6thrift4type4TypeC2ENS1_11exception_cENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN6apache6thrift4type4TypeC5ENS1_11exception_cENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x230): more undefined references to `apache::thrift::type::TypeName::__fbthrift_clear()' follow
07:13:06  /usr/bin/ld: /usr/local/lib/libthriftcpp2.a(RocketThriftRequests.cpp.o): in function `apache::thrift::type::SemiAnyStruct::~SemiAnyStruct()':
07:13:06  RocketThriftRequests.cpp:(.text._ZN6apache6thrift4type13SemiAnyStructD2Ev[_ZN6apache6thrift4type13SemiAnyStructD5Ev]+0x24): undefined reference to `apache::thrift::type::ProtocolUnion::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text._ZN6apache6thrift4type13SemiAnyStructD2Ev[_ZN6apache6thrift4type13SemiAnyStructD5Ev]+0x48): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketThriftRequests.cpp:(.text._ZN6apache6thrift4type13SemiAnyStructD2Ev[_ZN6apache6thrift4type13SemiAnyStructD5Ev]+0x70): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: /usr/local/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): in function `unsigned long apache::thrift::Serializer<apache::thrift::BinaryProtocolReader, apache::thrift::BinaryProtocolWriter>::deserialize<apache::thrift::type::SemiAnyStruct>(folly::IOBuf const*, apache::thrift::type::SemiAnyStruct&, apache::thrift::ExternalBufferSharing) [clone .isra.0]':
07:13:06  RocketClientChannel.cpp:(.text+0x974): undefined reference to `void apache::thrift::type::SemiAnyStruct::readNoXfer<apache::thrift::BinaryProtocolReader>(apache::thrift::BinaryProtocolReader*)'
07:13:06  /usr/bin/ld: /usr/local/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): in function `apache::thrift::type::ProtocolUnion::operator=(apache::thrift::type::ProtocolUnion const&) [clone .part.0]':
07:13:06  RocketClientChannel.cpp:(.text+0xc38): undefined reference to `apache::thrift::type::ProtocolUnion::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketClientChannel.cpp:(.text+0xc74): undefined reference to `apache::thrift::type::ProtocolUnion::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketClientChannel.cpp:(.text+0xc98): undefined reference to `apache::thrift::type::ProtocolUnion::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketClientChannel.cpp:(.text+0xcb8): undefined reference to `apache::thrift::type::ProtocolUnion::__fbthrift_clear()'
07:13:06  /usr/bin/ld: /usr/local/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): in function `bool apache::thrift::operator==<apache::thrift::type::Type&, apache::thrift::type::Type>(apache::thrift::field_ref<apache::thrift::type::Type&>, apache::thrift::type::Type const&) [clone .isra.0]':
07:13:06  RocketClientChannel.cpp:(.text+0x247c): undefined reference to `apache::thrift::type::TypeStruct::TypeStruct(apache::thrift::type::TypeStruct const&)'
07:13:06  /usr/bin/ld: RocketClientChannel.cpp:(.text+0x2488): undefined reference to `apache::thrift::type::TypeStruct::TypeStruct(apache::thrift::type::TypeStruct const&)'
07:13:06  /usr/bin/ld: RocketClientChannel.cpp:(.text+0x2494): undefined reference to `apache::thrift::type::TypeStruct::operator==(apache::thrift::type::TypeStruct const&) const'
07:13:06  /usr/bin/ld: RocketClientChannel.cpp:(.text+0x24b8): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketClientChannel.cpp:(.text+0x24e0): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketClientChannel.cpp:(.text+0x2500): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketClientChannel.cpp:(.text+0x2528): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketClientChannel.cpp:(.text+0x2574): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: /usr/local/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): in function `unsigned long apache::thrift::Serializer<apache::thrift::CompactProtocolReader, apache::thrift::CompactProtocolWriter>::deserialize<apache::thrift::type::SemiAnyStruct>(folly::IOBuf const*, apache::thrift::type::SemiAnyStruct&, apache::thrift::ExternalBufferSharing) [clone .isra.0]':
07:13:06  RocketClientChannel.cpp:(.text+0x2600): undefined reference to `void apache::thrift::type::SemiAnyStruct::readNoXfer<apache::thrift::CompactProtocolReader>(apache::thrift::CompactProtocolReader*)'
07:13:06  /usr/bin/ld: /usr/local/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): in function `folly::exception_wrapper apache::thrift::(anonymous namespace)::processFirstResponse<apache::thrift::(anonymous namespace)::LegacyResponseSerializationHandler>(unsigned short, apache::thrift::ResponseRpcMetadata&, std::unique_ptr<folly::IOBuf, std::default_delete<folly::IOBuf> >&, apache::thrift::(anonymous namespace)::LegacyResponseSerializationHandler&)':
07:13:06  RocketClientChannel.cpp:(.text+0x3cb4): undefined reference to `apache::thrift::type::ProtocolUnion::operator==(apache::thrift::type::ProtocolUnion const&) const'
07:13:06  /usr/bin/ld: RocketClientChannel.cpp:(.text+0x3d40): undefined reference to `apache::thrift::type::ProtocolUnion::operator==(apache::thrift::type::ProtocolUnion const&) const'
07:13:06  /usr/bin/ld: RocketClientChannel.cpp:(.text+0x3d58): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketClientChannel.cpp:(.text+0x3f9c): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketClientChannel.cpp:(.text+0x4364): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: /usr/local/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): in function `apache::thrift::type::Protocol const& apache::thrift::type::Protocol::get<(apache::thrift::type::StandardProtocol)2>()':
07:13:06  RocketClientChannel.cpp:(.text._ZN6apache6thrift4type8Protocol3getILNS1_16StandardProtocolE2EEERKS2_v[_ZN6apache6thrift4type8Protocol3getILNS1_16StandardProtocolE2EEERKS2_v]+0x54): undefined reference to `apache::thrift::type::ProtocolUnion::__fbthrift_clear()'
07:13:06  /usr/bin/ld: /usr/local/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): in function `apache::thrift::type::Protocol const& apache::thrift::type::Protocol::get<(apache::thrift::type::StandardProtocol)1>()':
07:13:06  RocketClientChannel.cpp:(.text._ZN6apache6thrift4type8Protocol3getILNS1_16StandardProtocolE1EEERKS2_v[_ZN6apache6thrift4type8Protocol3getILNS1_16StandardProtocolE1EEERKS2_v]+0x54): undefined reference to `apache::thrift::type::ProtocolUnion::__fbthrift_clear()'
07:13:06  /usr/bin/ld: /usr/local/lib/libthriftcpp2.a(RocketClientChannel.cpp.o): in function `apache::thrift::RocketClientChannel::SingleRequestSingleResponseCallback::onResponsePayload(folly::Try<apache::thrift::rocket::Payload>&&)':
07:13:06  RocketClientChannel.cpp:(.text._ZN6apache6thrift19RocketClientChannel35SingleRequestSingleResponseCallback17onResponsePayloadEON5folly3TryINS0_6rocket7PayloadEEE[_ZN6apache6thrift19RocketClientChannel35SingleRequestSingleResponseCallback17onResponsePayloadEON5folly3TryINS0_6rocket7PayloadEEE]+0x1888): undefined reference to `apache::thrift::type::ProtocolUnion::operator==(apache::thrift::type::ProtocolUnion const&) const'
07:13:06  /usr/bin/ld: RocketClientChannel.cpp:(.text._ZN6apache6thrift19RocketClientChannel35SingleRequestSingleResponseCallback17onResponsePayloadEON5folly3TryINS0_6rocket7PayloadEEE[_ZN6apache6thrift19RocketClientChannel35SingleRequestSingleResponseCallback17onResponsePayloadEON5folly3TryINS0_6rocket7PayloadEEE]+0x1914): undefined reference to `apache::thrift::type::ProtocolUnion::operator==(apache::thrift::type::ProtocolUnion const&) const'
07:13:06  /usr/bin/ld: RocketClientChannel.cpp:(.text._ZN6apache6thrift19RocketClientChannel35SingleRequestSingleResponseCallback17onResponsePayloadEON5folly3TryINS0_6rocket7PayloadEEE[_ZN6apache6thrift19RocketClientChannel35SingleRequestSingleResponseCallback17onResponsePayloadEON5folly3TryINS0_6rocket7PayloadEEE]+0x192c): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketClientChannel.cpp:(.text._ZN6apache6thrift19RocketClientChannel35SingleRequestSingleResponseCallback17onResponsePayloadEON5folly3TryINS0_6rocket7PayloadEEE[_ZN6apache6thrift19RocketClientChannel35SingleRequestSingleResponseCallback17onResponsePayloadEON5folly3TryINS0_6rocket7PayloadEEE]+0x1b38): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  /usr/bin/ld: RocketClientChannel.cpp:(.text._ZN6apache6thrift19RocketClientChannel35SingleRequestSingleResponseCallback17onResponsePayloadEON5folly3TryINS0_6rocket7PayloadEEE[_ZN6apache6thrift19RocketClientChannel35SingleRequestSingleResponseCallback17onResponsePayloadEON5folly3TryINS0_6rocket7PayloadEEE]+0x219c): undefined reference to `apache::thrift::type::TypeName::__fbthrift_clear()'
07:13:06  collect2: error: ld returned 1 exit status
07:13:06  make[3]: *** [Makefile:598: mock_mc_server] Error 1
07:13:06  make[3]: Leaving directory '/mnt/jenkins-data/workspace/mcrouter-diff-worker/mcrouter/lib/network/test'
07:13:06  make[2]: *** [Makefile:2446: all-recursive] Error 1
07:13:06  make[2]: Leaving directory '/mnt/jenkins-data/workspace/mcrouter-diff-worker/mcrouter/lib'
07:13:06  make[1]: *** [Makefile:2065: all-recursive] Error 1
07:13:06  make[1]: Leaving directory '/mnt/jenkins-data/workspace/mcrouter-diff-worker/mcrouter'
07:13:06  make: *** [Makefile:830: all] Error 2
```

This is due to a fbthrift refactor that changes the link targets for some source files. This change adds the relevant linker flags so that the mcrouter build is compatible with these changes.