### PR TITLE
Moving SR specific impls into ServiceInfo.cpp

### DIFF
--- a/mcrouter/CarbonRouterClient-inl.h
+++ b/mcrouter/CarbonRouterClient-inl.h
@@ -9,6 +9,7 @@
 
 #include "mcrouter/CarbonRouterInstance.h"
 #include "mcrouter/ForEachPossibleClient.h"
+#include "mcrouter/HostWithShard-fwd.h"
 #include "mcrouter/McrouterFiberContext.h"
 #include "mcrouter/ProxyRequestContextTyped.h"
 #include "mcrouter/lib/RouteHandleTraverser.h"

--- a/mcrouter/CarbonRouterClient.cpp
+++ b/mcrouter/CarbonRouterClient.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mcrouter/CarbonRouterClient.h"
+#include "mcrouter/mcrouter_sr_deps.h"
+
+namespace facebook::memcache::mcrouter::detail {
+
+bool srHostWithShardFuncCarbonRouterClient(
+    const HostWithShard& hostWithShard,
+    const RequestClass& requestClass,
+    uint64_t& hash,
+    uint64_t& hint) {
+  auto& host = hostWithShard.first;
+  if (!requestClass.is(RequestClass::kShadow) && host &&
+      host->location().getTWTaskID()) {
+    hash = *host->location().getTWTaskID();
+    hint = RoutingHintEncoder::encodeRoutingHint(hostWithShard);
+    return true;
+  }
+  return false;
+}
+
+} // namespace facebook::memcache::mcrouter::detail

--- a/mcrouter/HostWithShard-fwd-impl.h
+++ b/mcrouter/HostWithShard-fwd-impl.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+namespace facebook {
+namespace memcache {
+
+class HostInfo;
+using HostInfoPtr = std::shared_ptr<HostInfo>;
+using HostWithShard = std::pair<HostInfoPtr, int64_t>;
+
+} // namespace memcache
+} // namespace facebook

--- a/mcrouter/Makefile.am
+++ b/mcrouter/Makefile.am
@@ -207,6 +207,7 @@ libmcroutercore_a_SOURCES = \
   RoutingPrefix.h \
   RuntimeVarsData.cpp \
   RuntimeVarsData.h \
+  ServiceInfo.cpp \
   ServiceInfo-inl.h \
   ServiceInfo.h \
   stat_list.h \

--- a/mcrouter/Makefile.am
+++ b/mcrouter/Makefile.am
@@ -27,6 +27,7 @@ libmcroutercore_a_SOURCES = \
   AsyncWriterEntry.h \
   CallbackPool-inl.h \
   CallbackPool.h \
+  CarbonRouterClient.cpp \
   CarbonRouterClient-inl.h \
   CarbonRouterClient.h \
   CarbonRouterClientBase.cpp \

--- a/mcrouter/Makefile.am
+++ b/mcrouter/Makefile.am
@@ -85,6 +85,7 @@ libmcroutercore_a_SOURCES = \
   ProxyConfig.h \
   ProxyConfigBuilder.cpp \
   ProxyConfigBuilder.h \
+  ProxyDestination.cpp \
   ProxyDestination-inl.h \
   ProxyDestination.h \
   ProxyDestinationBase.cpp \

--- a/mcrouter/ProxyDestination-inl.h
+++ b/mcrouter/ProxyDestination-inl.h
@@ -5,10 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
+#include "mcrouter/ProxyDestination.h"
+
 #include <limits>
 #include <random>
-
-#include <folly/io/async/AsyncSSLSocket.h>
 
 #include "mcrouter/OptionsUtil.h"
 #include "mcrouter/ProxyBase.h"
@@ -19,13 +21,13 @@
 #include "mcrouter/lib/Reply.h"
 #include "mcrouter/lib/fbi/cpp/util.h"
 #include "mcrouter/lib/mc/protocol.h"
-#include "mcrouter/lib/network/AsyncTlsToPlaintextSocket.h"
 #include "mcrouter/lib/network/ConnectionDownReason.h"
 #include "mcrouter/lib/network/ConnectionOptions.h"
-#include "mcrouter/lib/network/McFizzClient.h"
-#include "mcrouter/lib/network/McSSLUtil.h"
 #include "mcrouter/lib/network/RpcStatsContext.h"
-#include "mcrouter/lib/network/TlsToPlainTransport.h"
+
+namespace folly {
+class AsyncTransport;
+} // namespace folly
 
 namespace facebook {
 namespace memcache {
@@ -264,6 +266,13 @@ void ProxyDestination<Transport>::resetInactive() {
   }
 }
 
+namespace detail {
+void incrementProxyTlsKtlsSslStats(
+    const folly::AsyncTransport& socket,
+    SecurityMech mech,
+    ProxyBase& proxy);
+} // namespace detail
+
 template <class Transport>
 void ProxyDestination<Transport>::initializeTransport() {
   assert(!transport_);
@@ -349,94 +358,19 @@ void ProxyDestination<Transport>::initializeTransport() {
 
   transport_->setConnectionStatusCallbacks(ConnectionStatusCallbacks{
       [this](
-          const folly::AsyncTransportWrapper& socket,
+          const folly::AsyncTransport& socket,
           int64_t numConnectRetries) mutable {
         setState(State::Up);
         proxy().stats().increment(num_connections_opened_stat);
 
         updatePoolStatConnections(true);
-        auto mech = accessPoint()->getSecurityMech();
-        if (mech == SecurityMech::TLS_TO_PLAINTEXT) {
-          if (const auto* tlsToPlainSock =
-                  socket.getUnderlyingTransport<TlsToPlainTransport>()) {
-            auto stats = tlsToPlainSock->getStats();
-            proxy().stats().increment(num_tls_to_plain_connections_opened_stat);
-            if (stats.sessionReuseAttempted) {
-              proxy().stats().increment(
-                  num_tls_to_plain_resumption_attempts_stat);
-            }
-            if (stats.sessionReuseSuccess) {
-              proxy().stats().increment(
-                  num_tls_to_plain_resumption_successes_stat);
-            }
-          } else if (
-              const auto* thriftTlsToPlainSock =
-                  socket.getUnderlyingTransport<AsyncTlsToPlaintextSocket>()) {
-            proxy().stats().increment(num_tls_to_plain_connections_opened_stat);
-
-            using Status = AsyncTlsToPlaintextSocket::SessionResumptionStatus;
-            switch (thriftTlsToPlainSock->getSessionResumptionStatus()) {
-              case Status::RESUMPTION_NOT_ATTEMPTED:
-                break;
-              case Status::RESUMPTION_ATTEMPTED_AND_SUCCEEDED:
-                proxy().stats().increment(
-                    num_tls_to_plain_resumption_successes_stat);
-                FOLLY_FALLTHROUGH;
-              case Status::RESUMPTION_ATTEMPTED_AND_FAILED:
-                proxy().stats().increment(
-                    num_tls_to_plain_resumption_attempts_stat);
-            };
-          } else {
-            proxy().stats().increment(num_tls_to_plain_fallback_failures_stat);
-          }
-        }
-        if (mech == SecurityMech::KTLS12) {
-          auto stats = McSSLUtil::getKtlsStats(socket);
-          if (stats) {
-            proxy().stats().increment(num_ktls_connections_opened_stat);
-            if (stats->sessionReuseAttempted) {
-              proxy().stats().increment(num_ktls_resumption_attempts_stat);
-            }
-            if (stats->sessionReuseSuccess) {
-              proxy().stats().increment(num_ktls_resumption_successes_stat);
-            }
-          } else {
-            proxy().stats().increment(num_ktls_fallback_failures_stat);
-          }
-        }
-        // no else if here in case the tls to plain didn't work - we can capture
-        // ssl socket stats here
-        if (const auto* sslSocket =
-                socket.getUnderlyingTransport<folly::AsyncSSLSocket>()) {
-          proxy().stats().increment(num_ssl_connections_opened_stat);
-          if (sslSocket->sessionResumptionAttempted()) {
-            proxy().stats().increment(num_ssl_resumption_attempts_stat);
-          }
-          if (sslSocket->getSSLSessionReused()) {
-            proxy().stats().increment(num_ssl_resumption_successes_stat);
-          }
-        } else if (
-            const auto* fizzSock =
-                socket.getUnderlyingTransport<McFizzClient>()) {
-          proxy().stats().increment(num_ssl_connections_opened_stat);
-          if (fizzSock->pskResumed()) {
-            proxy().stats().increment(num_ssl_resumption_successes_stat);
-            proxy().stats().increment(num_ssl_resumption_attempts_stat);
-          } else {
-            auto pskState = fizzSock->getState().pskType();
-            if (pskState && pskState.value() == fizz::PskType::Rejected) {
-              // session resumption was attempted, but failed
-              proxy().stats().increment(num_ssl_resumption_attempts_stat);
-            }
-          }
-        }
-
+        detail::incrementProxyTlsKtlsSslStats(
+            socket, accessPoint()->getSecurityMech(), proxy());
         if (numConnectRetries > 0) {
           proxy().stats().increment(num_connect_success_after_retrying_stat);
           proxy().stats().increment(
               num_connect_retries_stat, numConnectRetries);
         }
-
         updateConnectionClosedInternalStat();
       },
       [pdstnPtr = selfPtr_](
@@ -485,7 +419,7 @@ void ProxyDestination<Transport>::initializeTransport() {
 
   transport_->setAuthorizationCallbacks(AuthorizationCallbacks{
       [this](
-          const folly::AsyncTransportWrapper& socket,
+          const folly::AsyncTransport& socket,
           const ConnectionOptions& connectionOptions) mutable {
         if (auto& callback = proxy().router().svcIdentAuthCallbackFunc()) {
           if (!callback(socket, connectionOptions)) {

--- a/mcrouter/ProxyDestination.cpp
+++ b/mcrouter/ProxyDestination.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mcrouter/ProxyDestination.h"
+
+#include <folly/io/async/AsyncSSLSocket.h>
+
+#include "mcrouter/lib/network/AsyncTlsToPlaintextSocket.h"
+#include "mcrouter/lib/network/McFizzClient.h"
+#include "mcrouter/lib/network/McSSLUtil.h"
+#include "mcrouter/lib/network/TlsToPlainTransport.h"
+
+namespace facebook::memcache::mcrouter::detail {
+
+void incrementProxyTlsKtlsSslStats(
+    const folly::AsyncTransport& socket,
+    SecurityMech mech,
+    ProxyBase& proxy) {
+  if (mech == SecurityMech::TLS_TO_PLAINTEXT) {
+    if (const auto* tlsToPlainSock =
+            socket.getUnderlyingTransport<TlsToPlainTransport>()) {
+      auto stats = tlsToPlainSock->getStats();
+      proxy.stats().increment(num_tls_to_plain_connections_opened_stat);
+      if (stats.sessionReuseAttempted) {
+        proxy.stats().increment(num_tls_to_plain_resumption_attempts_stat);
+      }
+      if (stats.sessionReuseSuccess) {
+        proxy.stats().increment(num_tls_to_plain_resumption_successes_stat);
+      }
+    } else if (
+        const auto* thriftTlsToPlainSock =
+            socket.getUnderlyingTransport<AsyncTlsToPlaintextSocket>()) {
+      proxy.stats().increment(num_tls_to_plain_connections_opened_stat);
+
+      using Status = AsyncTlsToPlaintextSocket::SessionResumptionStatus;
+      switch (thriftTlsToPlainSock->getSessionResumptionStatus()) {
+        case Status::RESUMPTION_NOT_ATTEMPTED:
+          break;
+        case Status::RESUMPTION_ATTEMPTED_AND_SUCCEEDED:
+          proxy.stats().increment(num_tls_to_plain_resumption_successes_stat);
+          FOLLY_FALLTHROUGH;
+        case Status::RESUMPTION_ATTEMPTED_AND_FAILED:
+          proxy.stats().increment(num_tls_to_plain_resumption_attempts_stat);
+      };
+    } else {
+      proxy.stats().increment(num_tls_to_plain_fallback_failures_stat);
+    }
+  }
+  if (mech == SecurityMech::KTLS12) {
+    auto stats = McSSLUtil::getKtlsStats(socket);
+    if (stats) {
+      proxy.stats().increment(num_ktls_connections_opened_stat);
+      if (stats->sessionReuseAttempted) {
+        proxy.stats().increment(num_ktls_resumption_attempts_stat);
+      }
+      if (stats->sessionReuseSuccess) {
+        proxy.stats().increment(num_ktls_resumption_successes_stat);
+      }
+    } else {
+      proxy.stats().increment(num_ktls_fallback_failures_stat);
+    }
+  }
+  // no else if here in case the tls to plain didn't work - we can capture
+  // ssl socket stats here
+  if (const auto* sslSocket =
+          socket.getUnderlyingTransport<folly::AsyncSSLSocket>()) {
+    proxy.stats().increment(num_ssl_connections_opened_stat);
+    if (sslSocket->sessionResumptionAttempted()) {
+      proxy.stats().increment(num_ssl_resumption_attempts_stat);
+    }
+    if (sslSocket->getSSLSessionReused()) {
+      proxy.stats().increment(num_ssl_resumption_successes_stat);
+    }
+  } else if (
+      const auto* fizzSock = socket.getUnderlyingTransport<McFizzClient>()) {
+    proxy.stats().increment(num_ssl_connections_opened_stat);
+    if (fizzSock->pskResumed()) {
+      proxy.stats().increment(num_ssl_resumption_successes_stat);
+      proxy.stats().increment(num_ssl_resumption_attempts_stat);
+    } else {
+      auto pskState = fizzSock->getState().pskType();
+      if (pskState && pskState.value() == fizz::PskType::Rejected) {
+        // session resumption was attempted, but failed
+        proxy.stats().increment(num_ssl_resumption_attempts_stat);
+      }
+    }
+  }
+}
+
+} // namespace facebook::memcache::mcrouter::detail

--- a/mcrouter/Server-inl.h
+++ b/mcrouter/Server-inl.h
@@ -27,6 +27,7 @@
 #include "mcrouter/config.h"
 #include "mcrouter/lib/network/AsyncMcServer.h"
 #include "mcrouter/lib/network/AsyncMcServerWorker.h"
+#include "mcrouter/lib/network/McSSLUtil.h"
 #include "mcrouter/lib/network/Qos.h"
 #include "mcrouter/standalone_options.h"
 

--- a/mcrouter/ServiceInfo-inl.h
+++ b/mcrouter/ServiceInfo-inl.h
@@ -18,6 +18,7 @@
 #include <folly/json.h>
 
 #include "mcrouter/CarbonRouterInstance.h"
+#include "mcrouter/HostWithShard-fwd.h"
 #include "mcrouter/McrouterFiberContext.h"
 #include "mcrouter/Proxy.h"
 #include "mcrouter/ProxyConfigBuilder.h"
@@ -39,6 +40,11 @@ namespace facebook {
 namespace memcache {
 namespace mcrouter {
 namespace detail {
+
+bool srHostWithShardFuncRouteHandlesCommandDispatcher(
+    const HostWithShard& hostWithShard,
+    std::string& tree,
+    const int level);
 
 template <class RouterInfo>
 class RouteHandlesCommandDispatcher {
@@ -89,15 +95,8 @@ class RouteHandlesCommandDispatcher {
         [&tree, &level](
             const HostWithShard& hostWithShard,
             const RequestClass& /* unused */) {
-          const auto& host = hostWithShard.first;
-          bool haveHost = (host != nullptr);
-          tree.append(
-              std::string(level, ' ') + "host: " +
-              (haveHost ? host->location().getIp() : "unknown") + " port:" +
-              (haveHost ? folly::to<std::string>(host->location().getPort())
-                        : "unknown") +
-              '\n');
-          return false;
+          return srHostWithShardFuncRouteHandlesCommandDispatcher(
+              hostWithShard, tree, level);
         },
         [&tree, &level](
             const AccessPoint& srHost, const RequestClass& /* unused */) {

--- a/mcrouter/ServiceInfo.cpp
+++ b/mcrouter/ServiceInfo.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mcrouter/ServiceInfo.h"
+#include "mcrouter/mcrouter_sr_deps.h"
+
+namespace facebook::memcache::mcrouter::detail {
+
+bool srHostWithShardFuncRouteHandlesCommandDispatcher(
+    const HostWithShard& hostWithShard,
+    std::string& tree,
+    const int level) {
+  const auto& host = hostWithShard.first;
+  bool haveHost = (host != nullptr);
+  tree.append(
+      std::string(level, ' ') +
+      "host: " + (haveHost ? host->location().getIp() : "unknown") + " port:" +
+      (haveHost ? folly::to<std::string>(host->location().getPort())
+                : "unknown") +
+      '\n');
+  return false;
+}
+
+} // namespace facebook::memcache::mcrouter::detail

--- a/mcrouter/ServiceInfo.h
+++ b/mcrouter/ServiceInfo.h
@@ -11,6 +11,8 @@
 
 #include <folly/Range.h>
 
+#include "mcrouter/lib/network/gen/MemcacheMessages.h"
+
 namespace facebook {
 namespace memcache {
 namespace mcrouter {

--- a/mcrouter/configure.ac
+++ b/mcrouter/configure.ac
@@ -33,6 +33,7 @@ AC_CONFIG_LINKS([test/config.py:test/mcrouter_config.py])
 AC_CONFIG_LINKS([RouterRegistry.h:RouterRegistry-impl.h])
 AC_CONFIG_LINKS([ThriftAcceptor.h:ThriftAcceptor-impl.h])
 AC_CONFIG_LINKS([mcrouter_sr_deps.h:mcrouter_sr_deps-impl.h])
+AC_CONFIG_LINKS([HostWithShard-fwd.h:HostWithShard-fwd-impl.h])
 AC_CONFIG_AUX_DIR([build-aux])
 
 AM_INIT_AUTOMAKE([1.14 foreign dist-bzip2 nostdinc subdir-objects parallel-tests])

--- a/mcrouter/lib/RouteHandleTraverser.h
+++ b/mcrouter/lib/RouteHandleTraverser.h
@@ -16,7 +16,6 @@
 #include "mcrouter/McrouterFiberContext.h"
 #include "mcrouter/lib/PoolContext.h"
 #include "mcrouter/lib/network/AccessPoint.h"
-#include "mcrouter/mcrouter_sr_deps.h"
 
 namespace facebook {
 namespace memcache {

--- a/mcrouter/lib/RouteHandleTraverser.h
+++ b/mcrouter/lib/RouteHandleTraverser.h
@@ -12,6 +12,7 @@
 #include <memory>
 #include <vector>
 
+#include "mcrouter/HostWithShard-fwd.h"
 #include "mcrouter/McrouterFiberContext.h"
 #include "mcrouter/lib/PoolContext.h"
 #include "mcrouter/lib/network/AccessPoint.h"

--- a/mcrouter/lib/network/ThriftTransport-inl.h
+++ b/mcrouter/lib/network/ThriftTransport-inl.h
@@ -13,7 +13,6 @@
 #include <folly/ExceptionWrapper.h>
 
 #ifndef LIBMC_FBTRACE_DISABLE
-#include <contextprop/cpp/serde/SerDeHelper.h>
 #include <contextprop/if/gen-cpp2/ContextpropConstants_constants.h>
 #endif
 

--- a/mcrouter/lib/network/ThriftTransport.cpp
+++ b/mcrouter/lib/network/ThriftTransport.cpp
@@ -13,6 +13,10 @@
 #include <folly/io/async/EventBase.h>
 #include <thrift/lib/cpp2/async/RequestChannel.h>
 
+#ifndef LIBMC_FBTRACE_DISABLE
+#include <contextprop/cpp/serde/SerDeHelper.h>
+#endif
+
 #include "mcrouter/lib/fbi/cpp/LogFailure.h"
 #include "mcrouter/lib/network/AsyncTlsToPlaintextSocket.h"
 #include "mcrouter/lib/network/ConnectionOptions.h"


### PR DESCRIPTION
Summary:
This should improve compilation time for cpp files that include ServiceInfo.h
The idea is to extract namespace level functions that do not depend on any template parameters
and move its implementation to cpp file.
Also removing mcrouter_sr_deps.h from RouteHandleTraverser.h as a related change

Differential Revision: D43330742

