### PR TITLE
Run a python test in ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,3 +22,5 @@ jobs:
         run: |
           mkdir -p "$(pwd)"/mcrouter-install/install
           ./mcrouter/scripts/install_ubuntu_20.04.sh "$(pwd)"/mcrouter-install mcrouter
+      - name: Run a python test
+        run: PYTHONPATH=mcrouter/test python3 -B -m unittest -v test_ascii_error


### PR DESCRIPTION
I'm trying to investigate #407. I couldn't find anywhere in the current CI setup that actually runs the python tests. I'd be interested if running the tests in CI fails the same way that it is failing for me. Currently when I try to run these python tests in my CI setup it fails with error messages about 'cannot find module carbon'.