### PR TITLE
LowerBoundPrefixMap: default constructor to make empty map

### DIFF
--- a/mcrouter/lib/fbi/cpp/LowerBoundPrefixMap.h
+++ b/mcrouter/lib/fbi/cpp/LowerBoundPrefixMap.h
@@ -216,10 +216,11 @@ class LowerBoundPrefixMap {
   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
   // construction
-  LowerBoundPrefixMap() = default;
-
   explicit LowerBoundPrefixMap(
       std::vector<std::pair<std::string, T>> prefix2value);
+
+  LowerBoundPrefixMap()
+      : LowerBoundPrefixMap(std::vector<std::pair<std::string, T>>{}) {}
 
   class Builder {
    public:

--- a/mcrouter/lib/fbi/cpp/test/LowerBoundPrefixMapTest.cpp
+++ b/mcrouter/lib/fbi/cpp/test/LowerBoundPrefixMapTest.cpp
@@ -198,5 +198,10 @@ TEST(LowerBoundPrefixMapTest, OverrideValues) {
   }
 }
 
+TEST(LowerBoundPrefixMapTest, EmptyMap) {
+  LowerBoundPrefixMap<int> lbMap;
+  ASSERT_EQ(lbMap.findPrefix("a"), lbMap.end());
+}
+
 } // namespace
 } // namespace facebook::memcache


### PR DESCRIPTION
Summary:
Previous default constructor was creating a map with broken invariants.
This is maybe acceptable but untill proven that it has performance benefits, let's not.

Differential Revision: D49242615


