### PR TITLE
Missed C++20

### DIFF
--- a/mcrouter/lib/fbi/cpp/LowerBoundPrefixMap.h
+++ b/mcrouter/lib/fbi/cpp/LowerBoundPrefixMap.h
@@ -133,8 +133,7 @@ struct LowerBoundPrefixMapCommon {
 
   std::string_view str(std::uint32_t i) const {
     const char* f = chars_.data() + markers_[i];
-    const char* l = chars_.data() + markers_[i + 1];
-    return std::string_view{f, l};
+    return std::string_view{f, markers_[i + 1] - markers_[i]};
   }
 };
 


### PR DESCRIPTION
Summary: LowerBoundPrefixMap now needs to be C++17 and I missed this one

Differential Revision: D49559521


