### PR TITLE
Remove enableRoutePolicyMap v2 switch

### DIFF
--- a/mcrouter/ProxyConfig-inl.h
+++ b/mcrouter/ProxyConfig-inl.h
@@ -126,15 +126,12 @@ ProxyConfig<RouterInfo>::ProxyConfig(
       enableDeleteDistribution || enableCrossRegionDeleteRpc,
       "ProxyConfig: cannot disable cross-region delete rpc if distribution is disabled");
 
-  bool enablePolicyMapV2 = readBool("enable_policy_map_v2", false);
-
   bool enableAsyncDlBroadcast = readBool("enable_async_dl_broadcast", false);
 
   proxyRoute_ = std::make_shared<ProxyRoute<RouterInfo>>(
       proxy,
       routeSelectors,
       RootRouteRolloutOpts{
-          .enablePolicyMapV2 = enablePolicyMapV2,
           .enableDeleteDistribution = enableDeleteDistribution,
           .enableCrossRegionDeleteRpc = enableCrossRegionDeleteRpc,
           .enableAsyncDlBroadcast = enableAsyncDlBroadcast});

--- a/mcrouter/routes/RootRoute.h
+++ b/mcrouter/routes/RootRoute.h
@@ -27,7 +27,6 @@ namespace memcache {
 namespace mcrouter {
 
 struct RootRouteRolloutOpts {
-  bool enablePolicyMapV2 = false;
   bool enableDeleteDistribution = false;
   bool enableCrossRegionDeleteRpc = true;
   bool enableAsyncDlBroadcast = false;
@@ -49,8 +48,7 @@ class RootRoute {
         rhMap_(
             routeSelectors,
             opts_.default_route,
-            opts_.send_invalid_route_to_default,
-            rolloutOpts.enablePolicyMapV2),
+            opts_.send_invalid_route_to_default),
         defaultRoute_(opts_.default_route),
         enableDeleteDistribution_(rolloutOpts.enableDeleteDistribution),
         enableCrossRegionDeleteRpc_(rolloutOpts.enableCrossRegionDeleteRpc),

--- a/mcrouter/routes/RouteHandleMap-inl.h
+++ b/mcrouter/routes/RouteHandleMap-inl.h
@@ -56,14 +56,12 @@ using UniqueVectorMap = std::unordered_map<
 template <class RouteHandleIf>
 std::shared_ptr<RoutePolicyMap<RouteHandleIf>> makePolicyMap(
     UniqueVectorMap<RouteHandleIf>& uniqueVectors,
-    const RouteSelectorVector<RouteHandleIf>& v,
-    bool enableRoutePolicyV2) {
+    const RouteSelectorVector<RouteHandleIf>& v) {
   auto it = uniqueVectors.find(v);
   if (it != uniqueVectors.end()) {
     return it->second;
   }
-  return uniqueVectors[v] = std::make_shared<RoutePolicyMap<RouteHandleIf>>(
-             v, enableRoutePolicyV2);
+  return uniqueVectors[v] = std::make_shared<RoutePolicyMap<RouteHandleIf>>(v);
 }
 
 } // namespace detail
@@ -72,11 +70,9 @@ template <class RouteHandleIf>
 RouteHandleMap<RouteHandleIf>::RouteHandleMap(
     const RouteSelectorMap<RouteHandleIf>& routeSelectors,
     const RoutingPrefix& defaultRoute,
-    bool sendInvalidRouteToDefault,
-    bool enableRoutePolicyV2)
+    bool sendInvalidRouteToDefault)
     : defaultRoute_(defaultRoute),
-      sendInvalidRouteToDefault_(sendInvalidRouteToDefault),
-      enableRoutePolicyV2_(enableRoutePolicyV2) {
+      sendInvalidRouteToDefault_(sendInvalidRouteToDefault) {
   checkLogic(
       routeSelectors.find(defaultRoute_) != routeSelectors.end(),
       "invalid default route: {}",
@@ -115,16 +111,12 @@ RouteHandleMap<RouteHandleIf>::RouteHandleMap(
 
   // create corresponding RoutePolicyMaps
   detail::UniqueVectorMap<RouteHandleIf> uniqueVectors;
-  allRoutes_ = makePolicyMap(uniqueVectors, allRoutes, enableRoutePolicyV2_);
+  allRoutes_ = makePolicyMap(uniqueVectors, allRoutes);
   for (const auto& it : byRegion) {
-    byRegion_.emplace(
-        it.first,
-        makePolicyMap(uniqueVectors, it.second, enableRoutePolicyV2_));
+    byRegion_.emplace(it.first, makePolicyMap(uniqueVectors, it.second));
   }
   for (const auto& it : byRoute) {
-    byRoute_.emplace(
-        it.first,
-        makePolicyMap(uniqueVectors, it.second, enableRoutePolicyV2_));
+    byRoute_.emplace(it.first, makePolicyMap(uniqueVectors, it.second));
   }
 
   assert(byRoute_.find(defaultRoute_) != byRoute_.end());

--- a/mcrouter/routes/RouteHandleMap.h
+++ b/mcrouter/routes/RouteHandleMap.h
@@ -34,8 +34,7 @@ class RouteHandleMap {
   RouteHandleMap(
       const RouteSelectorMap<RouteHandleIf>& routeSelectors,
       const RoutingPrefix& defaultRoute,
-      bool sendInvalidRouteToDefault,
-      bool enableRoutePolicyV2);
+      bool sendInvalidRouteToDefault);
 
   /**
    * @return pointer to a precalculated vector of route handles that a request
@@ -58,7 +57,6 @@ class RouteHandleMap {
   const std::vector<std::shared_ptr<RouteHandleIf>> emptyV_;
   const RoutingPrefix& defaultRoute_;
   bool sendInvalidRouteToDefault_;
-  bool enableRoutePolicyV2_;
   std::shared_ptr<RoutePolicyMap<RouteHandleIf>> defaultRouteMap_;
 
   std::shared_ptr<RoutePolicyMap<RouteHandleIf>> allRoutes_;

--- a/mcrouter/routes/test/RootRouteTest.cpp
+++ b/mcrouter/routes/test/RootRouteTest.cpp
@@ -265,7 +265,6 @@ TEST_F(RootRouteTest, NoRoutingPrefixDeleteWithDistributionOnRoutesToDefault) {
       *proxy,
       getRouteSelectors(),
       RootRouteRolloutOpts{
-          .enablePolicyMapV2 = true,
           .enableDeleteDistribution = true,
           .enableCrossRegionDeleteRpc = true,
       }};
@@ -290,7 +289,6 @@ TEST_F(RootRouteTest, BroadcastPrefixDeleteWithDistributionOnRoutesToAll) {
       *proxy,
       getRouteSelectors(),
       RootRouteRolloutOpts{
-          .enablePolicyMapV2 = true,
           .enableDeleteDistribution = true,
           .enableCrossRegionDeleteRpc = true,
       }};
@@ -323,7 +321,6 @@ TEST_F(
       *proxy,
       getRouteSelectors(),
       RootRouteRolloutOpts{
-          .enablePolicyMapV2 = true,
           .enableDeleteDistribution = true,
           .enableCrossRegionDeleteRpc = true,
       }};
@@ -353,7 +350,6 @@ TEST_F(
       *proxy,
       getRouteSelectors(),
       RootRouteRolloutOpts{
-          .enablePolicyMapV2 = true,
           .enableDeleteDistribution = true,
           .enableCrossRegionDeleteRpc = false,
       }};
@@ -381,7 +377,6 @@ TEST_F(
       *proxy,
       getRouteSelectors(),
       RootRouteRolloutOpts{
-          .enablePolicyMapV2 = true,
           .enableDeleteDistribution = true,
           .enableCrossRegionDeleteRpc = false,
       }};

--- a/mcrouter/routes/test/RoutePolicyMapTest.cpp
+++ b/mcrouter/routes/test/RoutePolicyMapTest.cpp
@@ -48,38 +48,22 @@ struct MockPrefixSelectorRoute {
   }
 };
 
-struct MapsToTest {
-  explicit MapsToTest(const std::vector<SharedSelector>& clusters)
-      : m0(clusters, false), m1(clusters, true), m2(clusters) {}
-
-  RoutePolicyMap<RouteHandle> m0;
-  RoutePolicyMap<RouteHandle> m1;
-  RoutePolicyMapV2<RouteHandle> m2;
-};
-
-MapsToTest makeMap(const std::vector<MockPrefixSelectorRoute>& routes) {
+auto makeMap(const std::vector<MockPrefixSelectorRoute>& routes) {
   std::vector<SharedSelector> clusters(routes.begin(), routes.end());
-  return MapsToTest(clusters);
+  return RoutePolicyMap<RouteHandle>(clusters);
 }
 
-std::vector<int> routesFor(MapsToTest& maps, folly::StringPiece key) {
-  auto resForMap = [&](const auto& m) {
-    std::vector<int> res;
-    auto actual = m.getTargetsForKey(key);
-    res.reserve(actual.size());
-    for (const auto& x : actual) {
-      EXPECT_NE(x, nullptr);
-      res.push_back(x != nullptr ? *x : -1);
-    }
-    return res;
-  };
-
-  auto r0 = resForMap(maps.m0);
-  auto r1 = resForMap(maps.m1);
-  auto r2 = resForMap(maps.m2);
-  EXPECT_EQ(r0, r1) << key;
-  EXPECT_EQ(r0, r2) << key;
-  return r0;
+std::vector<int> routesFor(
+    const RoutePolicyMap<RouteHandle>& m,
+    folly::StringPiece key) {
+  std::vector<int> res;
+  auto actual = m.getTargetsForKey(key);
+  res.reserve(actual.size());
+  for (const auto& x : actual) {
+    EXPECT_NE(x, nullptr);
+    res.push_back(x != nullptr ? *x : -1);
+  }
+  return res;
 }
 
 TEST(RoutePolicyMapTest, NoPolicies) {


### PR DESCRIPTION
Summary: Removing old implementation, since the new one is rolled out in memcache.

Differential Revision: D53812885


