### PR TITLE
Fix OSS build

### DIFF
--- a/mcrouter/Makefile.am
+++ b/mcrouter/Makefile.am
@@ -135,7 +135,11 @@ libmcroutercore_a_SOURCES = \
   routes/FailoverRoute-inl.h \
   routes/FailoverRoute.h \
   routes/FailoverWithExptimeRouteFactory.h \
+  routes/HashStopAllowListRoute.h \
+  routes/HashStopAllowListRoute.cpp \
   routes/HostIdRouteFactory.h \
+  routes/KeyParseRoute.h \
+  routes/KeyParseRoute.cpp \
   routes/KeySplitRoute-inl.h \
   routes/KeySplitRoute.h \
   routes/L1L2CacheRouteFactory.h \
@@ -254,6 +258,7 @@ mcrouter_LDADD = \
   libmcroutercore.a \
   lib/libmcrouter.a \
   -lthriftcpp2 \
+  -lserverdbginfo \
   -ltransport \
   -lthriftanyrep \
   -lthrifttype \
@@ -264,6 +269,7 @@ mcrouter_LDADD = \
   -lthriftmetadata \
   -lasync \
   -lconcurrency \
+  -lruntime \
   -lthrift-core \
 	-lfmt \
   -lwangle \

--- a/mcrouter/configure.ac
+++ b/mcrouter/configure.ac
@@ -54,7 +54,7 @@ AX_PYTHON_DEVEL()
 AX_CXX_COMPILE_STDCXX_14([],[mandatory])
 LT_INIT
 
-CXXFLAGS="-fno-strict-aliasing -std=c++17 $CXXFLAGS"
+CXXFLAGS="-fno-strict-aliasing -std=c++20 $CXXFLAGS"
 CXXFLAGS="-W -Wall -Wextra -Wno-unused-parameter $CXXFLAGS"
 CXXFLAGS=" -Wno-missing-field-initializers -Wno-deprecated $CXXFLAGS"
 CXXFLAGS="-DLIBMC_FBTRACE_DISABLE -DDISABLE_COMPRESSION $CXXFLAGS"

--- a/mcrouter/lib/network/test/Makefile.am
+++ b/mcrouter/lib/network/test/Makefile.am
@@ -17,8 +17,9 @@ mock_mc_server_CPPFLAGS = -I$(top_srcdir)/..
 mock_mc_server_LDADD = \
 	$(top_builddir)/lib/libmcrouter.a \
 	-lthriftcpp2 \
+	-lserverdbginfo \
 	-ltransport \
-  -lthriftanyrep \
+	-lthriftanyrep \
 	-lthrifttype \
 	-lthrifttyperep \
 	-lthriftprotocol \
@@ -26,6 +27,7 @@ mock_mc_server_LDADD = \
 	-lthriftmetadata \
 	-lasync \
 	-lconcurrency \
+	-lruntime \
 	-lthrift-core \
 	-lfmt \
 	-lfizz \


### PR DESCRIPTION
mcrouter currently does not compile, since the build system is out of sync with recent changes.

Due to the use of `std::span` introduced in
9a24a4ee3985aa86de726c1e3259eea416d3970c, the project now requires C++20 to build. Update the `-std` flag accordingly, since the existing C++17 requirement was also introduced without much fanfare in 3181213fb2f314db6619d0d5b21e3e53804bc3a1 following a similar change.

Also update Automake files to reflect some newly added project files, and link against `serverdbginfo` and `runtime` from fbthrift, since they are now required.