### PR TITLE
Set -Wno-deprecated-declarations for the OSS build

### DIFF
--- a/mcrouter/configure.ac
+++ b/mcrouter/configure.ac
@@ -56,7 +56,7 @@ LT_INIT
 
 CXXFLAGS="-fno-strict-aliasing -std=c++17 $CXXFLAGS"
 CXXFLAGS="-W -Wall -Wextra -Wno-unused-parameter $CXXFLAGS"
-CXXFLAGS=" -Wno-missing-field-initializers -Wno-deprecated $CXXFLAGS"
+CXXFLAGS=" -Wno-missing-field-initializers -Wno-deprecated-declarations $CXXFLAGS"
 CXXFLAGS="-DLIBMC_FBTRACE_DISABLE -DDISABLE_COMPRESSION $CXXFLAGS"
 
 CFLAGS="-DLIBMC_FBTRACE_DISABLE -DDISABLE_COMPRESSION $CFLAGS"


### PR DESCRIPTION
Building mcrouter currently generates a high volume of deprecation warnings from generated thrift code and from OpenSSL-related deprecations in upstream folly. We already try to set `-Wno-deprecated`, but in modern GCC and clang `-Wno-deprecated-declarations` is needed to silence these warnings instead.