### PR TITLE
Externalize templates to speed up build

### DIFF
--- a/mcrouter/Makefile.am
+++ b/mcrouter/Makefile.am
@@ -89,6 +89,7 @@ libmcroutercore_a_SOURCES = \
   ProxyBase.h \
   ProxyConfig-inl.h \
   ProxyConfig.h \
+  ProxyConfig.cpp \
   ProxyConfigBuilder.cpp \
   ProxyConfigBuilder.h \
   ProxyDestination.cpp \

--- a/mcrouter/ProxyConfig-inl.h
+++ b/mcrouter/ProxyConfig-inl.h
@@ -15,6 +15,7 @@
 #include "mcrouter/Proxy.h"
 #include "mcrouter/lib/config/RouteHandleFactory.h"
 #include "mcrouter/lib/fbi/cpp/util.h"
+#include "mcrouter/lib/network/gen/MemcacheRouterInfo.h"
 #include "mcrouter/routes/McRouteHandleProvider.h"
 #include "mcrouter/routes/PrefixSelectorRoute.h"
 #include "mcrouter/routes/ProxyRoute.h"
@@ -23,6 +24,8 @@
 namespace facebook {
 namespace memcache {
 namespace mcrouter {
+
+extern template class ProxyConfig<facebook::memcache::MemcacheRouterInfo>;
 
 template <class RouterInfo>
 ProxyConfig<RouterInfo>::ProxyConfig(

--- a/mcrouter/ProxyConfig.cpp
+++ b/mcrouter/ProxyConfig.cpp
@@ -1,0 +1,7 @@
+#include "mcrouter/ProxyConfig.h"
+#include "mcrouter/ServiceInfo.h"
+#include "mcrouter/lib/network/gen/MemcacheRouterInfo.h"
+
+namespace facebook::memcache::mcrouter {
+template class ProxyConfig<facebook::memcache::MemcacheRouterInfo>;
+}

--- a/mcrouter/ServiceInfo-inl.h
+++ b/mcrouter/ServiceInfo-inl.h
@@ -39,6 +39,9 @@
 namespace facebook {
 namespace memcache {
 namespace mcrouter {
+
+extern template class ServiceInfo<facebook::memcache::MemcacheRouterInfo>;
+
 namespace detail {
 
 bool srHostInfoPtrFuncRouteHandlesCommandDispatcher(

--- a/mcrouter/ServiceInfo.cpp
+++ b/mcrouter/ServiceInfo.cpp
@@ -8,12 +8,13 @@
 #include "mcrouter/ServiceInfo.h"
 #include "mcrouter/mcrouter_sr_deps.h"
 
-namespace facebook::memcache::mcrouter::detail {
+namespace facebook::memcache::mcrouter {
 
+template class ServiceInfo<facebook::memcache::MemcacheRouterInfo>;
+
+namespace detail {
 bool srHostInfoPtrFuncRouteHandlesCommandDispatcher(
-    const HostInfoPtr& host,
-    std::string& tree,
-    const int level) {
+    const HostInfoPtr& host, std::string& tree, const int level) {
   bool haveHost = (host != nullptr);
   tree.append(
       std::string(level, ' ') +
@@ -23,5 +24,5 @@ bool srHostInfoPtrFuncRouteHandlesCommandDispatcher(
       '\n');
   return false;
 }
-
-} // namespace facebook::memcache::mcrouter::detail
+} // namespace detail
+} // namespace facebook::memcache::mcrouter


### PR DESCRIPTION

Profiling the mcrouter OSS build with ninjatracing + clang's -ftime-trace indicates that a significant amount of time is spent in repeated template instantiations for ProxyConfig and ServiceInfo (see [attached speedscope profile](https://github.com/user-attachments/files/18199055/mcrouter_build.zip)).

Add extern template declarations for these classes with their most common parameter (MemcacheRouterInfo) to reduce compile times. On a full build of mcrouter OSS with all tests, this reduces the build time from ~34 minutes to ~29 minutes.