### PR TITLE
Revert removal of files needed for mcrouter OSS

### DIFF
--- a/mcrouter/RouterRegistry-impl.h
+++ b/mcrouter/RouterRegistry-impl.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <stdexcept>
+
+#include <folly/Conv.h>
+
+#include "mcrouter/lib/network/gen/MemcacheRouterInfo.h"
+#include "mcrouter/lib/network/gen/MemcacheServer.h"
+
+/**
+ * Finds the proper carbon api according to 'routerName', and calls 'func'
+ * templated by the corresponding RouterInfo and RequestHandler.
+ *
+ * 'func' must be a function template, like the following:
+ *
+ * template <class RouterInfo, template <class> class RequestHandler>
+ * void myFunc(...) {
+ *   // ...
+ * }
+ *
+ *
+ * @param routerName  Name of the router (e.g. Memcache).
+ * @param func        The function template that will be called.
+ */
+#define CALL_BY_ROUTER_NAME(routerName, func, ...)                        \
+  do {                                                                    \
+    if ((routerName) == facebook::memcache::MemcacheRouterInfo::name) {   \
+      func<                                                               \
+          facebook::memcache::MemcacheRouterInfo,                         \
+          facebook::memcache::MemcacheRequestHandler>(__VA_ARGS__);       \
+    } else {                                                              \
+      throw std::invalid_argument(                                        \
+          folly::to<std::string>("Invalid router name: ", (routerName))); \
+    }                                                                     \
+  } while (false);
+
+#define CALL_BY_ROUTER_NAME_THRIFT(routerName, func, ...)               \
+  do {                                                                  \
+    throw std::invalid_argument(                                        \
+        folly::to<std::string>("Invalid router name: ", (routerName))); \
+  } while (false);

--- a/mcrouter/StandaloneConfig.cpp
+++ b/mcrouter/StandaloneConfig.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "StandaloneConfig.h"
+
+#include <functional>
+#include <unordered_map>
+
+namespace facebook {
+namespace memcache {
+namespace mcrouter {
+
+void standalonePreInitFromCommandLineOpts(
+    const std::unordered_map<std::string, std::string>& standaloneOptionsDict) {
+}
+
+void standaloneInit(
+    const McrouterOptions& opts,
+    const McrouterStandaloneOptions& standaloneOpts) {}
+
+void initStandaloneSSL() {}
+
+void initStandaloneSSLDualServer(
+    const McrouterStandaloneOptions& /* standaloneOpts */,
+    std::shared_ptr<apache::thrift::ThriftServer> /* thriftServer */) {}
+
+void finalizeStandaloneOptions(McrouterStandaloneOptions& opts) {}
+
+std::function<void(McServerSession&)> getConnectionAclChecker(
+    const std::string& /* serviceIdentity */,
+    bool /* enforce */) {
+  return [](McServerSession&) {};
+}
+std::function<bool(const folly::AsyncTransportWrapper*)>
+getThriftConnectionAclChecker(
+    const std::string& /* serviceIdentity */,
+    bool /* enforce */) {
+  return [](const folly::AsyncTransportWrapper*) { return true; };
+}
+
+MemcacheRequestAclCheckerCallback getMemcacheServerRequestAclCheckCallback(
+    ExternalStatsHandler&) {
+  return {};
+}
+
+void refreshMemcacheServerRequestAclChecker() {}
+
+} // namespace mcrouter
+} // namespace memcache
+} // namespace facebook

--- a/mcrouter/ThriftAcceptor-impl.h
+++ b/mcrouter/ThriftAcceptor-impl.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include <wangle/acceptor/Acceptor.h>
+
+namespace folly {
+class EventBase;
+} // namespace folly
+
+namespace apache {
+namespace thrift {
+class ThriftServer;
+} // namespace thrift
+} // namespace apache
+
+namespace facebook {
+namespace memcache {
+
+class ThriftAcceptorFactory final : public wangle::AcceptorFactory {
+  using ThriftAclCheckerFunc = bool (*)(const folly::AsyncTransportWrapper*);
+
+ public:
+  explicit ThriftAcceptorFactory(
+      apache::thrift::ThriftServer& server,
+      ThriftAclCheckerFunc /* unused */,
+      int trafficClass /* unused */)
+      : server_(server) {}
+  ~ThriftAcceptorFactory() override = default;
+
+  std::shared_ptr<wangle::Acceptor> newAcceptor(folly::EventBase* evb) override;
+
+ private:
+  apache::thrift::ThriftServer& server_;
+};
+
+} // namespace memcache
+} // namespace facebook


### PR DESCRIPTION
This reverts commit c3b6aca504d0d2dc9ad705d2058dc989ec2f9782, which accidentally removed some files necessary for building mcrouter OSS.