### PR TITLE
Fix OSS build

### DIFF
--- a/mcrouter/Makefile.am
+++ b/mcrouter/Makefile.am
@@ -266,10 +266,7 @@ mcrouter_LDADD = \
   -lasync \
   -lconcurrency \
   -lruntime \
-  -lthrift-core \
-	-lfmt \
-  -lwangle \
-  -lfolly
+  -lthrift-core
 
 mcrouter_CPPFLAGS = -I..
 

--- a/mcrouter/configure.ac
+++ b/mcrouter/configure.ac
@@ -132,20 +132,18 @@ AC_CHECK_LIB([double-conversion],[ceil],[],[AC_MSG_ERROR(
              [Please install double-conversion library])])
 AC_CHECK_LIB([dl], [dlopen], [])
 AC_CHECK_LIB([iberty], [cplus_demangle_v3_callback], [])
+AC_CHECK_LIB([fmt],[getenv],[],[AC_MSG_ERROR(
+             [Please install fmtlib])])
 AC_CHECK_LIB([folly],[getenv],[],[AC_MSG_ERROR(
              [Please install the folly library])])
 AC_CHECK_LIB([sodium],[sodium_init],[],[AC_MSG_ERROR(
              [Please install the libsodium library])])
 AC_CHECK_LIB([fizz],[getenv],[],[AC_MSG_ERROR(
              [Please install the fizz library])])
+AC_CHECK_LIB([wangle], [getenv], [], [AC_MSG_ERROR(
+             [Please install the wangle library])])
 AC_CHECK_HEADER([folly/Likely.h], [], [AC_MSG_ERROR(
                 [Could not find folly, please download from https://github.com/facebook/folly])], [])
-
-# Commenting out the wangle dependency from here, because there is a tricky
-# inter-library dependency that resolves with the right order of LDFLAGS, and
-# this dependency here messes the order.
-#AC_CHECK_LIB([wangle], [getenv], [], [AC_MSG_ERROR(
-#             [Please install the wangle library])])
 
 PKG_CHECK_MODULES([GTEST], [gtest], [], [
   # gtest-devel shipped by CentOS doesn't include a .pc file, so let's fallback

--- a/mcrouter/lib/Makefile.am
+++ b/mcrouter/lib/Makefile.am
@@ -59,6 +59,8 @@ libmcrouter_a_SOURCES = \
   StatsReply.h \
   WeightedCh3HashFunc.cpp \
   WeightedCh3HashFunc.h \
+  WeightedCh3RvHashFunc.cpp \
+  WeightedCh3RvHashFunc.h \
   WeightedChHashFuncBase.cpp \
   WeightedChHashFuncBase.h \
   WeightedRendezvousHashFunc.cpp \

--- a/mcrouter/lib/network/gen/Makefile.am
+++ b/mcrouter/lib/network/gen/Makefile.am
@@ -53,6 +53,8 @@ gen-cpp2/MemcacheAsyncClient.h: gen-cpp2/MemcacheService_constants.cpp
 gen-cpp2/MemcacheService_constants.cpp: gen-cpp2/MemcacheService_constants.h
 gen-cpp2/MemcacheService_constants.h: gen-cpp2/MemcacheService_types.cpp
 gen-cpp2/MemcacheService_types.cpp: gen-cpp2/MemcacheService_types.h
+gen-cpp2/MemcacheService_types_compact.cpp: gen-cpp2/MemcacheService_types.h
+gen-cpp2/MemcacheService_types_binary.cpp: gen-cpp2/MemcacheService_types.h
 gen-cpp2/MemcacheService_types.h: gen-cpp2/MemcacheService_types.tcc
 gen-cpp2/MemcacheService_types.tcc: gen-cpp2/MemcacheService_data.cpp
 gen-cpp2/MemcacheService_data.cpp: gen-cpp2/MemcacheService_data.h

--- a/mcrouter/lib/network/test/Makefile.am
+++ b/mcrouter/lib/network/test/Makefile.am
@@ -70,11 +70,7 @@ mock_mc_server_dual_LDADD = \
 	-lrpcmetadata \
 	-lasync \
 	-lconcurrency \
-	-lthrift-core \
-	-lfmt \
-	-lfizz \
-	-lwangle \
-	-lfolly
+	-lthrift-core
 
 libtest_util_a_SOURCES = \
   ClientSocket.cpp \
@@ -114,8 +110,4 @@ mcrouter_network_test_LDADD = \
   -lthriftcpp2 \
   -lthriftprotocol \
   -lrpcmetadata \
-  -ltransport \
-  -lwangle \
-  -lfizz \
-  -lsodium \
-  -lfolly
+  -ltransport

--- a/mcrouter/scripts/Makefile_ubuntu-24.04
+++ b/mcrouter/scripts/Makefile_ubuntu-24.04
@@ -5,7 +5,7 @@
 
 RECIPES_DIR := ./recipes
 
-all: .folly-done .fizz-done .wangle-done .fmt-done .mvfst-done .fbthrift-done .gtest-done
+all: .folly-done .fizz-done .wangle-done .fmt-done .mvfst-done .fbthrift-done
 	${RECIPES_DIR}/mcrouter.sh $(PKG_DIR) $(INSTALL_DIR) $(INSTALL_AUX_DIR)
 	touch $@
 
@@ -16,7 +16,7 @@ mcrouter:
 deps: .folly-done .fizz-done .wangle-done .fmt-done .mvfst-done .fbthrift-done
 	touch $@
 
-.folly-done: .fmt-done
+.folly-done: .fmt-done .fast_float-done
 	${RECIPES_DIR}/folly.sh $(PKG_DIR) $(INSTALL_DIR) $(INSTALL_AUX_DIR)
 	touch $@
 
@@ -26,6 +26,10 @@ deps: .folly-done .fizz-done .wangle-done .fmt-done .mvfst-done .fbthrift-done
 
 .wangle-done: .folly-done .fizz-done
 	${RECIPES_DIR}/wangle.sh $(PKG_DIR) $(INSTALL_DIR) $(INSTALL_AUX_DIR)
+	touch $@
+
+.fast_float-done:
+	${RECIPES_DIR}/fast_float.sh $(PKG_DIR) $(INSTALL_DIR) $(INSTALL_AUX_DIR)
 	touch $@
 
 .fmt-done:

--- a/mcrouter/scripts/install_ubuntu_24.04.sh
+++ b/mcrouter/scripts/install_ubuntu_24.04.sh
@@ -26,7 +26,6 @@ sudo apt-get install -y \
     libbz2-dev \
     libdouble-conversion-dev \
     libevent-dev \
-    libfast-float-dev \
     libgflags-dev \
     libgoogle-glog-dev \
     libgmock-dev \

--- a/mcrouter/scripts/recipes/fast_float.sh
+++ b/mcrouter/scripts/recipes/fast_float.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+source common.sh
+
+if [[ ! -d "$PKG_DIR/fast_float" ]]; then
+  git clone --depth 1 -b v8.0.2 https://github.com/fastfloat/fast_float.git
+  cd "$PKG_DIR/fast_float" || die "cd failed"
+  mkdir "$PKG_DIR/fast_float/build"
+fi
+
+cd "$PKG_DIR/fast_float/build" || die "cd fast_float failed"
+
+CXXFLAGS="$CXXFLAGS -fPIC" \
+  cmake .. -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR"
+cmake --build . && cmake --install .

--- a/mcrouter/tools/mcpiper/Makefile.am
+++ b/mcrouter/tools/mcpiper/Makefile.am
@@ -45,10 +45,7 @@ mcpiper_LDADD = \
 	-lrpcmetadata \
 	-lasync \
 	-lconcurrency \
-	-lthrift-core \
-	-lfizz \
-	-lfmt \
-	-lwangle \
-	-lfolly
+	-lruntime \
+	-lthrift-core
 
 mcpiper_CPPFLAGS = -I$(top_srcdir)/..


### PR DESCRIPTION
* folly requires fast_float >= 8.0.0 since  https://github.com/facebook/folly/commit/7aa9b2c8f788561f99afbbddd40230ed501c3e44,  whereas Ubuntu 24.04 packages version 3.9.0.  Add a build script for fast_float for use in the OSS build and use it instead of the distribution package.
* Add mcrouter/lib/WeightedCh3RvHashFunc.cpp and the corresponding header to the Automake build.
* Add missing dependencies for generated MemcacheService types.
* Fix fmtlib link order, remove duplicate link line entries.