### PR TITLE
Use folly::Init for mock servers to avoid glog warnings

### DIFF
--- a/mcrouter/lib/network/test/MockMcServer.cpp
+++ b/mcrouter/lib/network/test/MockMcServer.cpp
@@ -13,15 +13,13 @@
 #include <glog/logging.h>
 
 #include <folly/Format.h>
-#include <folly/Singleton.h>
+#include <folly/init/Init.h>
 #include <folly/logging/Init.h>
 
 #include "mcrouter/lib/network/AsyncMcServer.h"
 #include "mcrouter/lib/network/AsyncMcServerWorker.h"
-#include "mcrouter/lib/network/CarbonMessageDispatcher.h"
 #include "mcrouter/lib/network/McServerRequestContext.h"
 #include "mcrouter/lib/network/gen/MemcacheServer.h"
-#include "mcrouter/lib/network/test/MockMc.h"
 #include "mcrouter/lib/network/test/MockMcOnRequest.h"
 
 /**
@@ -69,7 +67,7 @@ void serverLoop(
 FOLLY_INIT_LOGGING_CONFIG(".=WARNING,folly=INFO; default:async=true");
 
 int main(int argc, char** argv) {
-  folly::SingletonVault::singleton()->registrationComplete();
+  folly::Init init(&argc, &argv, folly::InitOptions{}.useGFlags(false).removeFlags(false));
 
   AsyncMcServer::Options opts;
   opts.worker.versionString = "MockMcServer-1.0";

--- a/mcrouter/lib/network/test/MockMcServerDual.cpp
+++ b/mcrouter/lib/network/test/MockMcServerDual.cpp
@@ -13,8 +13,8 @@
 #include <glog/logging.h>
 
 #include <folly/Format.h>
-#include <folly/Singleton.h>
 #include <folly/executors/IOThreadPoolExecutor.h>
+#include <folly/init/Init.h>
 #include <folly/io/async/AsyncSignalHandler.h>
 #include <folly/io/async/EventBase.h>
 #include <folly/logging/Init.h>
@@ -23,8 +23,6 @@
 #include "mcrouter/ExecutorObserver.h"
 #include "mcrouter/lib/network/AsyncMcServer.h"
 #include "mcrouter/lib/network/AsyncMcServerWorker.h"
-#include "mcrouter/lib/network/CarbonMessageDispatcher.h"
-#include "mcrouter/lib/network/McServerRequestContext.h"
 #include "mcrouter/lib/network/ServerLoad.h"
 #include "mcrouter/lib/network/test/MockMcThriftServerHandler.h"
 
@@ -98,7 +96,7 @@ class ShutdownSignalHandler : public folly::AsyncSignalHandler {
 };
 
 int main(int argc, char** argv) {
-  folly::SingletonVault::singleton()->registrationComplete();
+  folly::Init init(&argc, &argv, folly::InitOptions{}.useGFlags(false).removeFlags(false));
 
   AsyncMcServer::Options asyncOpts;
   asyncOpts.worker.versionString = "MockMcServer-1.0";

--- a/mcrouter/lib/network/test/MockMcThriftServer.cpp
+++ b/mcrouter/lib/network/test/MockMcThriftServer.cpp
@@ -13,7 +13,7 @@
 #include <glog/logging.h>
 
 #include <folly/Format.h>
-#include <folly/Singleton.h>
+#include <folly/init/Init.h>
 #include <folly/logging/Init.h>
 #include <thrift/lib/cpp2/server/ThriftServer.h>
 
@@ -52,7 +52,7 @@ void sigHandler(int /* signo */) {
 }
 
 int main(int argc, char** argv) {
-  folly::SingletonVault::singleton()->registrationComplete();
+  folly::Init init(&argc, &argv, folly::InitOptions{}.useGFlags(false).removeFlags(false));
 
   uint16_t port = 0;
   int existingSocketFd = 0;


### PR DESCRIPTION
As D57798214 but for the standalone mock binaries used in integration testing. This avoids repeated "WARNING: Logging before InitGoogleLogging() is written to STDERR" errors in test logs.