### PR TITLE
Skip ServiceRouter tests when SR is not linked

### DIFF
--- a/mcrouter/test/cpp_unit_tests/mc_route_handle_provider_test.cpp
+++ b/mcrouter/test/cpp_unit_tests/mc_route_handle_provider_test.cpp
@@ -164,6 +164,9 @@ TEST(McRouteHandleProvider, pool_route) {
 }
 
 TEST(McRouteHandleProvider, sr_route) {
+  if (!MemcacheRouterInfo::isSRLinked()) {
+    GTEST_SKIP() << "ServiceRouter is not available in the OSS build";
+  }
   TestSetup setup;
   auto rh = setup.getRoute(kSimpleSRRoute);
   EXPECT_TRUE(rh != nullptr);
@@ -183,6 +186,9 @@ TEST(McRouteHandleProvider, pool_route_with_invalid_fanout) {
 }
 
 TEST(McRouteHandleProvider, bucketized_sr_route_and_mcreplay_asynclogRoutes) {
+  if (!MemcacheRouterInfo::isSRLinked()) {
+    GTEST_SKIP() << "ServiceRouter is not available in the OSS build";
+  }
   TestSetup setup;
   auto rh = setup.getRoute(kBucketizedSRRoute);
   EXPECT_TRUE(rh != nullptr);


### PR DESCRIPTION
SR is an optional dependency for mcrouter, especially OSS, so skip tests exercising SR-specific functionality in the OSS build.