### PR TITLE
Update tests after miss-on-get removal

### DIFF
--- a/mcrouter/test/test_mcrouter_serialized.py
+++ b/mcrouter/test/test_mcrouter_serialized.py
@@ -257,7 +257,7 @@ class TestFailoverWithLimit(McrouterTestCase):
         # now every 5th request should succeed
         for _ in range(10):
             for _ in range(4):
-                self.assertIsNone(mcr.get("key"))
+                self.assertIn("SERVER_ERROR", mcr.get("key"))
             self.assertEqual(mcr.get("key"), "value.gut")
 
 
@@ -284,7 +284,7 @@ class TestFailoverWithLimitWithTKO(McrouterTestCase):
         # now every 5th request should succeed
         for _ in range(10):
             for _ in range(4):
-                self.assertIsNone(mcr.get("key"))
+                self.assertIn("SERVER_ERROR", mcr.get("key"))
             self.assertEqual(mcr.get("key"), "value.gut")
 
 
@@ -314,7 +314,7 @@ class TestFailoverWithLimitWithErrors(McrouterTestCase):
         # all subsequest requests would fail until timeouts become
         # as TKOs
         for _ in range(18):
-            self.assertIsNone(mcr.get("key"))
+            self.assertIn("SERVER_ERROR", mcr.get("key"))
 
         # From here it should behave like the testcase above because
         # all destinations are declared TKO and ratelimiting is not
@@ -322,7 +322,7 @@ class TestFailoverWithLimitWithErrors(McrouterTestCase):
         for _ in range(10):
             self.assertEqual(mcr.get("key"), "value.gut")
             for _ in range(4):
-                self.assertIsNone(mcr.get("key"))
+                self.assertIn("SERVER_ERROR", mcr.get("key"))
 
 
 class TestFailoverWithLimitWithTKOAndErrors(McrouterTestCase):
@@ -346,9 +346,9 @@ class TestFailoverWithLimitWithTKOAndErrors(McrouterTestCase):
         # operations would succeed before rate limiting kicks in)
         for _ in range(4):
             self.assertEqual(mcr.get("key"), "value.gut")
-        self.assertIsNone(mcr.get("key"))
+        self.assertIn("SERVER_ERROR", mcr.get("key"))
         # All dests are TKO now, so now every 5th request should succeed
         for _ in range(10):
             self.assertEqual(mcr.get("key"), "value.gut")
             for _ in range(4):
-                self.assertIsNone(mcr.get("key"))
+                self.assertIn("SERVER_ERROR", mcr.get("key"))

--- a/mcrouter/test/test_mcrouter_states.py
+++ b/mcrouter/test/test_mcrouter_states.py
@@ -61,8 +61,8 @@ class TestMcrouterStates(McrouterTestCase):
 
         # down aka hard tko
         self.mc.terminate()
-        self.assertEqual(mcr.get("key"), None)
-        self.assertEqual(c2.get("key"), None)
+        self.assertIn("SERVER_ERROR", mcr.get("key"))
+        self.assertIn("SERVER_ERROR", c2.get("key"))
         stat = mcr.stats()
         self.assertEqual(stat["num_servers_up"], "0")
         self.assertEqual(stat["num_servers_down"], "2")


### PR DESCRIPTION
Since D73554883, mcrouter no longer converts GET errors to misses, which necessitates updating some relevant tests:

* Update test_mcrouter_serialized and test_mcrouter_states to expect an error response instead of a miss where necessary.
* Update CarbonRouterClient.basicUsageRemoteThreadClientThreadAffinityMulti to also accept a CONNECT_TIMEOUT as an expected error response (this may be the case on some local systems and GitHub Actions). Make the assertion less cryptic.

Original errors from CI:
```
 ======================================================================
FAIL: test_failover_limit (mcrouter.test.test_mcrouter_serialized.TestFailoverWithLimit)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/fbcode_builder_getdeps-ZhomeZrunnerZworkZmcrouterZmcrouterZbuildZfbcode_builder/build/mcrouter-CeBnYGY6hczXARtSui5EWvho5spSAKd88uS5EUCPCYM/mcrouter/test/test_mcrouter_serialized.py", line 260, in test_failover_limit
    self.assertIsNone(mcr.get("key"))
AssertionError: 'SERVER_ERROR 307 busy' is not None

======================================================================
FAIL: test_failover_limit (mcrouter.test.test_mcrouter_serialized.TestFailoverWithLimitWithErrors)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/fbcode_builder_getdeps-ZhomeZrunnerZworkZmcrouterZmcrouterZbuildZfbcode_builder/build/mcrouter-CeBnYGY6hczXARtSui5EWvho5spSAKd88uS5EUCPCYM/mcrouter/test/test_mcrouter_serialized.py", line 317, in test_failover_limit
    self.assertIsNone(mcr.get("key"))
AssertionError: 'SERVER_ERROR Reply timeout' is not None

======================================================================
FAIL: test_failover_limit (mcrouter.test.test_mcrouter_serialized.TestFailoverWithLimitWithTKO)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/fbcode_builder_getdeps-ZhomeZrunnerZworkZmcrouterZmcrouterZbuildZfbcode_builder/build/mcrouter-CeBnYGY6hczXARtSui5EWvho5spSAKd88uS5EUCPCYM/mcrouter/test/test_mcrouter_serialized.py", line 287, in test_failover_limit
    self.assertIsNone(mcr.get("key"))
AssertionError: 'SERVER_ERROR 307 busy' is not None

======================================================================
FAIL: test_failover_limit (mcrouter.test.test_mcrouter_serialized.TestFailoverWithLimitWithTKOAndErrors)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/fbcode_builder_getdeps-ZhomeZrunnerZworkZmcrouterZmcrouterZbuildZfbcode_builder/build/mcrouter-CeBnYGY6hczXARtSui5EWvho5spSAKd88uS5EUCPCYM/mcrouter/test/test_mcrouter_serialized.py", line 349, in test_failover_limit
    self.assertIsNone(mcr.get("key"))
AssertionError: 'SERVER_ERROR 307 busy' is not None

----------------------------------------------------------------------
Ran 10 tests in 37.751s

FAILED (failures=4)

======================================================================
FAIL: test_mcrouter_states (mcrouter.test.test_mcrouter_states.TestMcrouterStates)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/fbcode_builder_getdeps-ZhomeZrunnerZworkZmcrouterZmcrouterZbuildZfbcode_builder/build/mcrouter-CeBnYGY6hczXARtSui5EWvho5spSAKd88uS5EUCPCYM/mcrouter/test/test_mcrouter_states.py", line 64, in test_mcrouter_states
    self.assertEqual(mcr.get("key"), None)
AssertionError: 'SERVER_ERROR Server unavailable. Reason: mc_res_connect_error' != None

 [ RUN      ] CarbonRouterClient.basicUsageRemoteThreadClientThreadAffinityMulti
/home/runner/work/mcrouter/mcrouter/mcrouter/test/cpp_unit_tests/McrouterClientUsage.cpp:303: Failure
Value of: *reply.result_ref() == carbon::Result::CONNECT_ERROR || *reply.result_ref() == carbon::Result::TKO
  Actual: false
Expected: true
```