### PR TITLE
Fix OSS build

### DIFF
--- a/mcrouter/Makefile.am
+++ b/mcrouter/Makefile.am
@@ -266,7 +266,8 @@ mcrouter_LDADD = \
   -lasync \
   -lconcurrency \
   -lruntime \
-  -lthrift-core
+  -lthrift-core \
+  -lcommon
 
 mcrouter_CPPFLAGS = -I..
 

--- a/mcrouter/lib/network/test/Makefile.am
+++ b/mcrouter/lib/network/test/Makefile.am
@@ -29,6 +29,7 @@ mock_mc_server_LDADD = \
 	-lconcurrency \
 	-lruntime \
 	-lthrift-core \
+	-lcommon \
 	-lfmt \
 	-lfizz \
 	-lwangle \
@@ -50,6 +51,7 @@ mock_mc_thrift_server_LDADD = \
 	-lasync \
 	-lconcurrency \
 	-lthrift-core \
+	-lcommon \
 	-lfmt \
 	-lfizz \
 	-lwangle \
@@ -70,7 +72,8 @@ mock_mc_server_dual_LDADD = \
 	-lrpcmetadata \
 	-lasync \
 	-lconcurrency \
-	-lthrift-core
+	-lthrift-core \
+	-lcommon
 
 libtest_util_a_SOURCES = \
   ClientSocket.cpp \
@@ -110,4 +113,5 @@ mcrouter_network_test_LDADD = \
   -lthriftcpp2 \
   -lthriftprotocol \
   -lrpcmetadata \
-  -ltransport
+  -ltransport \
+  -lcommon

--- a/mcrouter/tools/mcpiper/Makefile.am
+++ b/mcrouter/tools/mcpiper/Makefile.am
@@ -46,6 +46,7 @@ mcpiper_LDADD = \
 	-lasync \
 	-lconcurrency \
 	-lruntime \
-	-lthrift-core
+	-lthrift-core \
+	-lcommon
 
 mcpiper_CPPFLAGS = -I$(top_srcdir)/..


### PR DESCRIPTION
It's also necessary to link `libcommon.a` from fbthrift after D78290177.