### PR TITLE
Do not build Fizz examples

### DIFF
--- a/mcrouter/scripts/recipes/fizz.sh
+++ b/mcrouter/scripts/recipes/fizz.sh
@@ -20,5 +20,5 @@ fi
 
 cd "$PKG_DIR/fizz/fizz/" || die "cd fail"
 
-cmake . -G Ninja -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" -DBUILD_TESTS=OFF
+cmake . -G Ninja -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" -DBUILD_TESTS=OFF -DBUILD_EXAMPLES=OFF
 cmake --build . && cmake --install .


### PR DESCRIPTION
These are currently failing because the upstream CMake build doesn't yet default to C++20. As they aren't needed by mcrouter anyways, let's skip building them.