### PR TITLE
Fix OSS build

### DIFF
--- a/mcrouter/McrouterLogger.cpp
+++ b/mcrouter/McrouterLogger.cpp
@@ -162,6 +162,7 @@ bool McrouterLogger::start() {
   } else {
     // If default path is not available and TW backup is enabled, try backup
     // path
+#ifndef MCROUTER_OSS_BUILD
     if (router_.opts().enable_tw_crash_config_backup_path &&
         additionalLogger_) {
       auto backupPath = additionalLogger_->getBackupStatsRootPath();
@@ -177,11 +178,14 @@ bool McrouterLogger::start() {
         return false;
       }
     } else {
+#endif
       LOG(WARNING) << "Can't create or chmod " << router_.opts().stats_root
                    << ", disabling stats logging";
       return false;
     }
+#ifndef MCROUTER_OSS_BUILD
   }
+#endif
 
   boost::filesystem::path path(statsRoot_);
   path /= getStatPrefix(router_.opts()) + "." + kStatsStartupOptionsSfx;

--- a/mcrouter/lib/carbon/Makefile.am
+++ b/mcrouter/lib/carbon/Makefile.am
@@ -29,7 +29,7 @@ gen-cpp2/carbon_result_types.h: gen-cpp2/carbon_result_types_custom_protocol.h
 gen-cpp2/carbon_result_types_custom_protocol.h: gen-cpp2/carbon_result_data.cpp
 gen-cpp2/carbon_result_data.cpp: gen-cpp2/carbon_result_data.h
 gen-cpp2/carbon_result_data.h: carbon_result.thrift
-	@FBTHRIFT@ -gen mstch_cpp2:stack_arguments,sync_methods_return_try,include_prefix=mcrouter/lib/carbon/ carbon_result.thrift
+	@FBTHRIFT@ -gen mstch_cpp2:stack_arguments,sync_methods_return_try,include_prefix=mcrouter/lib/carbon/ -I $(INSTALL_DIR)/include/ carbon_result.thrift
 
 gen-cpp2/carbon_types.cpp: gen-cpp2/carbon_types.h
 gen-cpp2/carbon_types_binary.cpp: gen-cpp2/carbon_types.h

--- a/mcrouter/test/cpp_unit_tests/options_test.cpp
+++ b/mcrouter/test/cpp_unit_tests/options_test.cpp
@@ -50,9 +50,11 @@ TEST(OptionsSetFromDictTest, sanity) {
   /* unchanged */
   EXPECT_TRUE(opts.num_proxies == 4);
 
+#ifndef MCROUTER_OSS_BUILD
   dict.clear();
   dict["enable_tw_crash_config_backup_path"] = "1";
   e = opts.updateFromDict(dict);
   EXPECT_TRUE(e.empty());
   EXPECT_TRUE(opts.enable_tw_crash_config_backup_path);
+#endif
 }


### PR DESCRIPTION
D89334763 introduced the use of `include "thrift/annotation/thrift.thrift"` in `carbon_result.thrift`.

```
Making all in carbon
make[4]: Entering directory '/home/runner/work/mcrouter/mcrouter/mcrouter/lib/carbon'
/home/runner/work/mcrouter/mcrouter/mcrouter-install/install/bin//thrift1  -gen mstch_cpp2:stack_arguments,sync_methods_return_try,include_prefix=mcrouter/lib/carbon/ carbon_result.thrift
/home/runner/work/mcrouter/mcrouter/mcrouter-install/install/bin//thrift1  -gen mstch_cpp2:stack_arguments,sync_methods_return_try,include_prefix=mcrouter/lib/carbon/ -I /home/runner/work/mcrouter/mcrouter/mcrouter-install/install/include/ carbon.thrift
[ERROR:carbon_result.thrift:8] Could not find include file thrift/annotation/thrift.thrift
make[4]: *** [Makefile:521: gen-cpp2/carbon_result_data.h] Error 1
make[4]: *** Waiting for unfinished jobs....
```
This should be fixed by `-I $(INSTALL_DIR)/include/` for generating gen-cpp2 for carbon_result.thrift.

D89393569 exposed the component of Tupperware which is a Meta-only tool, so guarding the section related to TW with MCROUTER_OSS_BUILD to fix the issue for OSS build.