### PR TITLE
Fix 'occured' -> 'occurred' typo in file_observer_sleep_before_update_ms option help

### DIFF
--- a/mcrouter/mcrouter_options_list.h
+++ b/mcrouter/mcrouter_options_list.h
@@ -217,7 +217,7 @@ MCROUTER_OPTION_INTEGER(
     1000,
     "file-observer-sleep-before-update-ms",
     no_short,
-    "How long to sleep for after an update occured"
+    "How long to sleep for after an update occurred"
     " (a hack to avoid partial writes).")
 
 MCROUTER_OPTION_INTEGER(


### PR DESCRIPTION
The option help text for `file_observer_sleep_before_update_ms` in `mcrouter/mcrouter_options_list.h:220` reads:

```cpp
"How long to sleep for after an update occured"
" (a hack to avoid partial writes)."
```

This text is surfaced via `mcrouter --help` and any tooling that introspects option metadata. String-literal-only change.