### PR TITLE
Propagate `PrivacyLibAgenticContext` through Carbon requests and Thrift transport headers (#479)

### DIFF
--- a/mcrouter/lib/carbon/MessageCommon.h
+++ b/mcrouter/lib/carbon/MessageCommon.h
@@ -42,6 +42,9 @@ class MessageCommon {
 
   static constexpr std::string_view kKcbIdentityHeader = "kcb_identity";
 
+  static constexpr std::string_view kPrivacyLibAgenticContextHeader =
+      "privacylib-propagation";
+
  protected:
   std::string traceContext_;
 };

--- a/mcrouter/lib/carbon/RequestCommon.cpp
+++ b/mcrouter/lib/carbon/RequestCommon.cpp
@@ -22,6 +22,7 @@ RequestCommon::RequestCommon(const RequestCommon& other)
   cryptoAuthToken_ = other.cryptoAuthToken_;
   replyBitMask_ = other.replyBitMask_;
   clientIdentifier_ = other.clientIdentifier_;
+  privacyLibAgenticContext_ = other.privacyLibAgenticContext_;
 }
 
 RequestCommon& RequestCommon::operator=(const RequestCommon& other) {
@@ -30,6 +31,7 @@ RequestCommon& RequestCommon::operator=(const RequestCommon& other) {
     cryptoAuthToken_ = other.cryptoAuthToken_;
     replyBitMask_ = other.replyBitMask_;
     clientIdentifier_ = other.clientIdentifier_;
+    privacyLibAgenticContext_ = other.privacyLibAgenticContext_;
     uniqueId_ = other.uniqueId_;
   }
   return *this;
@@ -79,6 +81,15 @@ const std::optional<std::string>& RequestCommon::getClientIdentifier()
 void RequestCommon::setClientIdentifier(
     folly::StringPiece clientIdentifier) noexcept {
   clientIdentifier_ = clientIdentifier.str();
+}
+
+const std::optional<std::string>& RequestCommon::getPrivacyLibAgenticContext()
+    const {
+  return privacyLibAgenticContext_;
+}
+
+void RequestCommon::setPrivacyLibAgenticContext(std::string&& context) {
+  privacyLibAgenticContext_.emplace(std::move(context));
 }
 
 const std::optional<folly::IPAddress>& RequestCommon::getSourceIpAddr()

--- a/mcrouter/lib/carbon/RequestCommon.h
+++ b/mcrouter/lib/carbon/RequestCommon.h
@@ -72,6 +72,10 @@ class RequestCommon : public MessageCommon {
 
   void setClientIdentifier(folly::StringPiece clientIdentifier) noexcept;
 
+  const std::optional<std::string>& getPrivacyLibAgenticContext() const;
+
+  void setPrivacyLibAgenticContext(std::string&& context);
+
   const std::optional<folly::IPAddress>& getSourceIpAddr() const noexcept;
 
   void setSourceIpAddr(const folly::IPAddress& sourceIpAddr) noexcept;
@@ -95,6 +99,8 @@ class RequestCommon : public MessageCommon {
   std::optional<std::string> cryptoAuthToken_;
   // Hash string of primary (non-host) tls client identities
   std::optional<std::string> clientIdentifier_;
+  // Privacylib agentic context in base64-encoded serialized format
+  std::optional<std::string> privacyLibAgenticContext_;
   // Source ip address.
   std::optional<folly::IPAddress> sourceIpAddr_;
   // write timestamp

--- a/mcrouter/lib/carbon/example/gen/HelloGoodbyeThriftTransport.h
+++ b/mcrouter/lib/carbon/example/gen/HelloGoodbyeThriftTransport.h
@@ -56,6 +56,10 @@ folly::Try<apache::thrift::RpcResponseComplete<hellogoodbye::GoodbyeReply>> send
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
   }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -95,6 +99,10 @@ folly::Try<apache::thrift::RpcResponseComplete<hellogoodbye::HelloReply>> sendSy
   if (FOLLY_UNLIKELY(request.getClientIdentifier().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
+  }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
   rpcOptions.setContextPropMask(0);
 
@@ -138,6 +146,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McVersionReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getClientIdentifier().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
+  }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
   rpcOptions.setContextPropMask(0);
 

--- a/mcrouter/lib/carbon/test/gen/AThriftTransport.h
+++ b/mcrouter/lib/carbon/test/gen/AThriftTransport.h
@@ -54,6 +54,10 @@ folly::Try<apache::thrift::RpcResponseComplete<carbon::test::A::TestAReply>> sen
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
   }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -93,6 +97,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McVersionReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getClientIdentifier().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
+  }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
   rpcOptions.setContextPropMask(0);
 

--- a/mcrouter/lib/carbon/test/gen/BThriftTransport.h
+++ b/mcrouter/lib/carbon/test/gen/BThriftTransport.h
@@ -54,6 +54,10 @@ folly::Try<apache::thrift::RpcResponseComplete<carbon::test::B::TestBReply>> sen
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
   }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -93,6 +97,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McVersionReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getClientIdentifier().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
+  }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
   rpcOptions.setContextPropMask(0);
 

--- a/mcrouter/lib/carbon/test/gen/CarbonTestThriftTransport.h
+++ b/mcrouter/lib/carbon/test/gen/CarbonTestThriftTransport.h
@@ -54,6 +54,10 @@ folly::Try<apache::thrift::RpcResponseComplete<carbon::test::TestReply>> sendSyn
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
   }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -94,6 +98,10 @@ folly::Try<apache::thrift::RpcResponseComplete<carbon::test::TestReplyStringKey>
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
   }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -133,6 +141,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McVersionReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getClientIdentifier().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
+  }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
   rpcOptions.setContextPropMask(0);
 

--- a/mcrouter/lib/carbon/test/gen/CarbonThriftTestThriftTransport.h
+++ b/mcrouter/lib/carbon/test/gen/CarbonThriftTestThriftTransport.h
@@ -54,6 +54,10 @@ folly::Try<apache::thrift::RpcResponseComplete<carbon::test::CustomReply>> sendS
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
   }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -93,6 +97,10 @@ folly::Try<apache::thrift::RpcResponseComplete<carbon::test::DummyThriftReply>> 
   if (FOLLY_UNLIKELY(request.getClientIdentifier().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
+  }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
   rpcOptions.setContextPropMask(0);
 
@@ -134,6 +142,10 @@ folly::Try<apache::thrift::RpcResponseComplete<carbon::test::ThriftTestReply>> s
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
   }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -173,6 +185,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McVersionReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getClientIdentifier().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
+  }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
   rpcOptions.setContextPropMask(0);
 

--- a/mcrouter/lib/network/gen/MemcacheThriftTransport.h
+++ b/mcrouter/lib/network/gen/MemcacheThriftTransport.h
@@ -54,6 +54,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McAddReply>> sendSyncHelper(
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
   }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -93,6 +97,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McAppendReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getClientIdentifier().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
+  }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
   rpcOptions.setContextPropMask(0);
 
@@ -134,6 +142,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McCasReply>> sendSyncHelper(
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
   }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -173,6 +185,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McDecrReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getClientIdentifier().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
+  }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
   rpcOptions.setContextPropMask(0);
 
@@ -214,6 +230,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McDeleteReply>> sendSyncHelper(
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
   }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -253,6 +273,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McFlushAllReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getClientIdentifier().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
+  }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
   rpcOptions.setContextPropMask(0);
 
@@ -294,6 +318,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McFlushReReply>> sendSyncHelper(
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
   }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -333,6 +361,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McGatReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getClientIdentifier().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
+  }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
   rpcOptions.setContextPropMask(0);
 
@@ -374,6 +406,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McGatsReply>> sendSyncHelper(
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
   }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -413,6 +449,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McGetReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getClientIdentifier().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
+  }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
   rpcOptions.setContextPropMask(0);
 
@@ -454,6 +494,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McGetsReply>> sendSyncHelper(
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
   }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -493,6 +537,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McIncrReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getClientIdentifier().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
+  }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
   rpcOptions.setContextPropMask(0);
 
@@ -534,6 +582,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McLeaseGetReply>> sendSyncHelper(
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
   }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -573,6 +625,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McLeaseSetReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getClientIdentifier().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
+  }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
   rpcOptions.setContextPropMask(0);
 
@@ -614,6 +670,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McMetagetReply>> sendSyncHelper(
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
   }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -653,6 +713,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McPrependReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getClientIdentifier().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
+  }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
   rpcOptions.setContextPropMask(0);
 
@@ -694,6 +758,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McReplaceReply>> sendSyncHelper(
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
   }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -733,6 +801,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McSetReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getClientIdentifier().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
+  }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
   rpcOptions.setContextPropMask(0);
 
@@ -774,6 +846,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McTouchReply>> sendSyncHelper(
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
   }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -813,6 +889,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McVersionReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getClientIdentifier().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
+  }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
   rpcOptions.setContextPropMask(0);
 


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebook/hhvm/pull/9778

X-link: https://github.com/facebookresearch/DCPerf/pull/621

Propagate the `PrivacyLibAgenticContext` as a `privacylib-propagation` Thrift header from clients through mcrouter to DevProxy.

We capture the context before enqueuing the request in the mcrouter message queue. And then we set the header in the mcrouter Thrift transport layer.

Diagram:

```
Caller thread (RequestContext available)
    │
    ├── CacheClientImplBase::buildSingleRequest()  ← captures context here
    │   └── carbonReq.setPrivacyLibAgenticContext(serialized)
    │
    ├── RequestBuilderHelper::updateTaoRequestCommonPart()  ← also captures here (TAO-specific)
    │   └── carbonReq.setPrivacyLibAgenticContext(serialized)
    │
    ╧ ── MessageQueue ──────────────────── (RequestContext lost, but field survives)
    │
    └── ThriftTransport::sendSyncHelper()
        └── request.getPrivacyLibAgenticContext().has_value()
            └── rpcOptions.setWriteHeader("privacylib-propagation", value)
```

We are focusing on Thrift transport exclusively as we are trying to close gaps in DevProxy layer.

Reviewed By: ghostonhuang

Differential Revision: D105269091


