### PR TITLE
add kcb_identity field on RequestCommon + thrift header write (#480)

### DIFF
--- a/mcrouter/lib/carbon/RequestCommon.cpp
+++ b/mcrouter/lib/carbon/RequestCommon.cpp
@@ -23,6 +23,7 @@ RequestCommon::RequestCommon(const RequestCommon& other)
   replyBitMask_ = other.replyBitMask_;
   clientIdentifier_ = other.clientIdentifier_;
   privacyLibAgenticContext_ = other.privacyLibAgenticContext_;
+  kcbIdentity_ = other.kcbIdentity_;
 }
 
 RequestCommon& RequestCommon::operator=(const RequestCommon& other) {
@@ -32,6 +33,7 @@ RequestCommon& RequestCommon::operator=(const RequestCommon& other) {
     replyBitMask_ = other.replyBitMask_;
     clientIdentifier_ = other.clientIdentifier_;
     privacyLibAgenticContext_ = other.privacyLibAgenticContext_;
+    kcbIdentity_ = other.kcbIdentity_;
     uniqueId_ = other.uniqueId_;
   }
   return *this;
@@ -90,6 +92,15 @@ const std::optional<std::string>& RequestCommon::getPrivacyLibAgenticContext()
 
 void RequestCommon::setPrivacyLibAgenticContext(std::string&& context) {
   privacyLibAgenticContext_.emplace(std::move(context));
+}
+
+const std::optional<std::string>& RequestCommon::getKcbIdentity()
+    const noexcept {
+  return kcbIdentity_;
+}
+
+void RequestCommon::setKcbIdentity(folly::StringPiece kcbIdentity) noexcept {
+  kcbIdentity_ = kcbIdentity.str();
 }
 
 const std::optional<folly::IPAddress>& RequestCommon::getSourceIpAddr()

--- a/mcrouter/lib/carbon/RequestCommon.h
+++ b/mcrouter/lib/carbon/RequestCommon.h
@@ -76,6 +76,12 @@ class RequestCommon : public MessageCommon {
 
   void setPrivacyLibAgenticContext(std::string&& context);
 
+  // Returns the resolved Generalized KCB ACL identity name, if any.
+  // Used by the transport layer to write the kcb_identity thrift header.
+  const std::optional<std::string>& getKcbIdentity() const noexcept;
+
+  void setKcbIdentity(folly::StringPiece kcbIdentity) noexcept;
+
   const std::optional<folly::IPAddress>& getSourceIpAddr() const noexcept;
 
   void setSourceIpAddr(const folly::IPAddress& sourceIpAddr) noexcept;
@@ -101,6 +107,10 @@ class RequestCommon : public MessageCommon {
   std::optional<std::string> clientIdentifier_;
   // Privacylib agentic context in base64-encoded serialized format
   std::optional<std::string> privacyLibAgenticContext_;
+  // Resolved Generalized KCB ACL identity name (DataTypeConfig.kcbIdentity).
+  // When set, the transport writes it as the kcb_identity thrift header so
+  // the UCache server can bind the cache key to this ACL group.
+  std::optional<std::string> kcbIdentity_;
   // Source ip address.
   std::optional<folly::IPAddress> sourceIpAddr_;
   // write timestamp

--- a/mcrouter/lib/carbon/example/gen/HelloGoodbyeThriftTransport.h
+++ b/mcrouter/lib/carbon/example/gen/HelloGoodbyeThriftTransport.h
@@ -60,6 +60,10 @@ folly::Try<apache::thrift::RpcResponseComplete<hellogoodbye::GoodbyeReply>> send
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -103,6 +107,10 @@ folly::Try<apache::thrift::RpcResponseComplete<hellogoodbye::HelloReply>> sendSy
   if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
   }
   rpcOptions.setContextPropMask(0);
 
@@ -150,6 +158,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McVersionReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
   }
   rpcOptions.setContextPropMask(0);
 

--- a/mcrouter/lib/carbon/test/gen/AThriftTransport.h
+++ b/mcrouter/lib/carbon/test/gen/AThriftTransport.h
@@ -58,6 +58,10 @@ folly::Try<apache::thrift::RpcResponseComplete<carbon::test::A::TestAReply>> sen
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -101,6 +105,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McVersionReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
   }
   rpcOptions.setContextPropMask(0);
 

--- a/mcrouter/lib/carbon/test/gen/BThriftTransport.h
+++ b/mcrouter/lib/carbon/test/gen/BThriftTransport.h
@@ -58,6 +58,10 @@ folly::Try<apache::thrift::RpcResponseComplete<carbon::test::B::TestBReply>> sen
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -101,6 +105,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McVersionReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
   }
   rpcOptions.setContextPropMask(0);
 

--- a/mcrouter/lib/carbon/test/gen/CarbonTestThriftTransport.h
+++ b/mcrouter/lib/carbon/test/gen/CarbonTestThriftTransport.h
@@ -58,6 +58,10 @@ folly::Try<apache::thrift::RpcResponseComplete<carbon::test::TestReply>> sendSyn
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -102,6 +106,10 @@ folly::Try<apache::thrift::RpcResponseComplete<carbon::test::TestReplyStringKey>
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -145,6 +153,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McVersionReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
   }
   rpcOptions.setContextPropMask(0);
 

--- a/mcrouter/lib/carbon/test/gen/CarbonThriftTestThriftTransport.h
+++ b/mcrouter/lib/carbon/test/gen/CarbonThriftTestThriftTransport.h
@@ -58,6 +58,10 @@ folly::Try<apache::thrift::RpcResponseComplete<carbon::test::CustomReply>> sendS
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -101,6 +105,10 @@ folly::Try<apache::thrift::RpcResponseComplete<carbon::test::DummyThriftReply>> 
   if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
   }
   rpcOptions.setContextPropMask(0);
 
@@ -146,6 +154,10 @@ folly::Try<apache::thrift::RpcResponseComplete<carbon::test::ThriftTestReply>> s
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -189,6 +201,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McVersionReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
   }
   rpcOptions.setContextPropMask(0);
 

--- a/mcrouter/lib/network/gen/MemcacheThriftTransport.h
+++ b/mcrouter/lib/network/gen/MemcacheThriftTransport.h
@@ -58,6 +58,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McAddReply>> sendSyncHelper(
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -101,6 +105,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McAppendReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
   }
   rpcOptions.setContextPropMask(0);
 
@@ -146,6 +154,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McCasReply>> sendSyncHelper(
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -189,6 +201,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McDecrReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
   }
   rpcOptions.setContextPropMask(0);
 
@@ -234,6 +250,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McDeleteReply>> sendSyncHelper(
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -277,6 +297,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McFlushAllReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
   }
   rpcOptions.setContextPropMask(0);
 
@@ -322,6 +346,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McFlushReReply>> sendSyncHelper(
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -365,6 +393,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McGatReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
   }
   rpcOptions.setContextPropMask(0);
 
@@ -410,6 +442,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McGatsReply>> sendSyncHelper(
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -453,6 +489,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McGetReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
   }
   rpcOptions.setContextPropMask(0);
 
@@ -498,6 +538,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McGetsReply>> sendSyncHelper(
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -541,6 +585,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McIncrReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
   }
   rpcOptions.setContextPropMask(0);
 
@@ -586,6 +634,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McLeaseGetReply>> sendSyncHelper(
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -629,6 +681,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McLeaseSetReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
   }
   rpcOptions.setContextPropMask(0);
 
@@ -674,6 +730,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McMetagetReply>> sendSyncHelper(
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -717,6 +777,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McPrependReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
   }
   rpcOptions.setContextPropMask(0);
 
@@ -762,6 +826,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McReplaceReply>> sendSyncHelper(
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -805,6 +873,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McSetReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
   }
   rpcOptions.setContextPropMask(0);
 
@@ -850,6 +922,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McTouchReply>> sendSyncHelper(
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -893,6 +969,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McVersionReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
   }
   rpcOptions.setContextPropMask(0);
 


### PR DESCRIPTION
Summary:

Adds the `kcbIdentity` field to `carbon::RequestCommon` (mirrors the existing `clientIdentifier` and `cryptoAuthToken` fields), and updates the carbon compiler template to emit a `setWriteHeader(kKcbIdentityHeader, ...)` block in every generated `*ThriftTransport.h`. This is the wire-format support for Generalized KCB: callers set `request.setKcbIdentity(aclName)` and the transport writes the `kcb_identity` thrift header on the outgoing thrift call so the UCache server can bind the cache key to the named ACL group

Reviewed By: antonf

Differential Revision: D104245265


