### PR TITLE
Fix typos in comments and option help text

### DIFF
--- a/mcrouter/CarbonRouterInstance.h
+++ b/mcrouter/CarbonRouterInstance.h
@@ -36,7 +36,7 @@ class McrouterManager;
 class ProxyThread;
 
 /**
- * Class to to read CPU metrics of the mcrouter proxy threads
+ * Class to read CPU metrics of the mcrouter proxy threads
  * based on a FunctionScheduler
  */
 class CpuStatsWorker {

--- a/mcrouter/ConfigApi.h
+++ b/mcrouter/ConfigApi.h
@@ -169,7 +169,7 @@ class ConfigApi : public ConfigApiIf {
    * Save a piece of config source to disk.
    *
    * @param sourcePrefix  Where this config comes from (e.g. file).
-   * @param name          Name of this peice of config.
+   * @param name          Name of this piece of config.
    *                      NOTE: sourcePrefix + name should uniquely identify
    *                      this config source.
    * @param contents      The actual config.
@@ -191,7 +191,7 @@ class ConfigApi : public ConfigApiIf {
    * Reads the given config source from backup file.
    *
    * @param sourcePrefix  Where this config comes from (e.g. file).
-   * @param name          Name of this peice of config.
+   * @param name          Name of this piece of config.
    * @param contents      Output parameter that will hold the content of the
    *                      backup file
    *

--- a/mcrouter/lib/network/AsyncMcClientImpl.cpp
+++ b/mcrouter/lib/network/AsyncMcClientImpl.cpp
@@ -688,7 +688,7 @@ void AsyncMcClientImpl::writeSuccess() noexcept {
   } while (!last);
 
   // It is possible that we're already processing error, but still have a
-  // successfull write.
+  // successful write.
   if (connectionState_ == ConnectionState::Error) {
     processShutdown("Connection was in ERROR state.");
   }

--- a/mcrouter/lib/network/McServerSession.h
+++ b/mcrouter/lib/network/McServerSession.h
@@ -118,7 +118,7 @@ class McServerSession
    * Creates a new session.
    * Sessions manage their own lifetime.
    * A session will self-destruct right after an onCloseFinish() callback
-   * call, by which point all of the following must have occured:
+   * call, by which point all of the following must have occurred:
    *   1) All outstanding requests have been replied and pending
    *      writes have been completed/errored out.
    *   2) The outgoing connection is closed, either via an explicit close()

--- a/mcrouter/lib/network/SocketConnector.cpp
+++ b/mcrouter/lib/network/SocketConnector.cpp
@@ -49,7 +49,7 @@ class ConnectHelper : public folly::AsyncSocket::ConnectCallback,
  private:
   // the async socket to connect
   folly::AsyncSocket::UniquePtr socket_;
-  // promise we will fullfill
+  // promise we will fulfill
   folly::Promise<folly::AsyncSocket::UniquePtr> promise_;
 };
 

--- a/mcrouter/mcrouter_options_list.h
+++ b/mcrouter/mcrouter_options_list.h
@@ -217,7 +217,7 @@ MCROUTER_OPTION_INTEGER(
     1000,
     "file-observer-sleep-before-update-ms",
     no_short,
-    "How long to sleep for after an update occured"
+    "How long to sleep for after an update occurred"
     " (a hack to avoid partial writes).")
 
 MCROUTER_OPTION_INTEGER(

--- a/mcrouter/routes/StagingRoute.h
+++ b/mcrouter/routes/StagingRoute.h
@@ -66,7 +66,7 @@ namespace mcrouter {
  * route.
  *
  * Expiration time (TTL) for objects from warm -> staging update requests is
- * calculated based on the object's metadata retreived from warm route async.
+ * calculated based on the object's metadata retrieved from warm route async.
  */
 class StagingRoute {
  public:


### PR DESCRIPTION
This batches a handful of high-confidence spelling fixes in code comments, a doc-comment, and one CLI option help string. All changes are **comment / string-only** — no logic, behavior, or public API changes. Verified by inspection.

| File | Before | After |
|------|--------|-------|
| `mcrouter/CarbonRouterInstance.h` | Class **to to** read CPU metrics | Class **to** read CPU metrics |
| `mcrouter/ConfigApi.h` (x2) | Name of this **peice** of config | Name of this **piece** of config |
| `mcrouter/lib/network/AsyncMcClientImpl.cpp` | **successfull** write | **successful** write |
| `mcrouter/lib/network/McServerSession.h` | must have **occured** | must have **occurred** |
| `mcrouter/lib/network/SocketConnector.cpp` | promise we will **fullfill** | promise we will **fulfill** |
| `mcrouter/mcrouter_options_list.h` | after an update **occured** | after an update **occurred** |
| `mcrouter/routes/StagingRoute.h` | metadata **retreived** from warm route | metadata **retrieved** from warm route |

British spellings (e.g. `behaviour`, `cancelled`) were intentionally left untouched.